### PR TITLE
Devel directory service impl

### DIFF
--- a/manager-rs/Cargo.lock
+++ b/manager-rs/Cargo.lock
@@ -368,6 +368,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "directory-service"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "structopt",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/manager-rs/Cargo.lock
+++ b/manager-rs/Cargo.lock
@@ -373,6 +373,8 @@ version = "0.1.0"
 dependencies = [
  "prost",
  "rand 0.7.3",
+ "serde",
+ "serde_yaml",
  "sqlx",
  "structopt",
  "tempfile",

--- a/manager-rs/Cargo.lock
+++ b/manager-rs/Cargo.lock
@@ -372,8 +372,10 @@ name = "directory-service"
 version = "0.1.0"
 dependencies = [
  "prost",
+ "rand 0.7.3",
  "sqlx",
  "structopt",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",

--- a/manager-rs/Cargo.lock
+++ b/manager-rs/Cargo.lock
@@ -372,6 +372,7 @@ name = "directory-service"
 version = "0.1.0"
 dependencies = [
  "prost",
+ "sqlx",
  "structopt",
  "thiserror",
  "tokio",

--- a/manager-rs/Cargo.toml
+++ b/manager-rs/Cargo.toml
@@ -2,6 +2,7 @@
 
 members= [
     "dauth-service",
+    "directory-service",
     "auth-vector",
     "auth-testing",
 ]

--- a/manager-rs/configs/directory.yaml
+++ b/manager-rs/configs/directory.yaml
@@ -1,0 +1,2 @@
+host_address: "127.0.0.1:8900"
+database_path: "./directory_sqlite.db"

--- a/manager-rs/directory-service/Cargo.toml
+++ b/manager-rs/directory-service/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "directory-service"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tonic = "^0.6.1"
+prost = "0.9"
+tokio = { version = "^1.13.0", features = ["macros", "rt-multi-thread"]}
+tracing = "0.1.29"
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.3.2"
+thiserror = "1.0"
+structopt = "0.3"
+
+[build-dependencies]
+tonic-build = "0.6"

--- a/manager-rs/directory-service/Cargo.toml
+++ b/manager-rs/directory-service/Cargo.toml
@@ -15,6 +15,10 @@ tracing-subscriber = "0.3.2"
 thiserror = "1.0"
 structopt = "0.3"
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls" , "sqlite" ] }
+rand = "0.7"
+
+[dev-dependencies]
+tempfile = "3.3"
 
 [build-dependencies]
 tonic-build = "0.6"

--- a/manager-rs/directory-service/Cargo.toml
+++ b/manager-rs/directory-service/Cargo.toml
@@ -14,6 +14,7 @@ tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.2"
 thiserror = "1.0"
 structopt = "0.3"
+sqlx = { version = "0.5", features = [ "runtime-tokio-rustls" , "sqlite" ] }
 
 [build-dependencies]
 tonic-build = "0.6"

--- a/manager-rs/directory-service/Cargo.toml
+++ b/manager-rs/directory-service/Cargo.toml
@@ -13,6 +13,8 @@ tracing = "0.1.29"
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.2"
 thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
 structopt = "0.3"
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls" , "sqlite" ] }
 rand = "0.7"

--- a/manager-rs/directory-service/build.rs
+++ b/manager-rs/directory-service/build.rs
@@ -1,0 +1,12 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .compile(
+            &[
+                "../../protos/directory.proto",
+            ],
+            &["../../protos"],
+        )?;
+    Ok(())
+}

--- a/manager-rs/directory-service/build.rs
+++ b/manager-rs/directory-service/build.rs
@@ -2,11 +2,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_client(true)
         .build_server(true)
-        .compile(
-            &[
-                "../../protos/directory.proto",
-            ],
-            &["../../protos"],
-        )?;
+        .compile(&["../../protos/directory.proto"], &["../../protos"])?;
     Ok(())
 }

--- a/manager-rs/directory-service/build.rs
+++ b/manager-rs/directory-service/build.rs
@@ -1,6 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
-        .build_client(true)
         .build_server(true)
         .compile(&["../../protos/directory.proto"], &["../../protos"])?;
     Ok(())

--- a/manager-rs/directory-service/src/data/config.rs
+++ b/manager-rs/directory-service/src/data/config.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+/// Holds all configuration data from a corresponding YAML file
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DirectoryConfig {
+    pub host_address: String,
+    pub database_path: String,
+}

--- a/manager-rs/directory-service/src/data/context.rs
+++ b/manager-rs/directory-service/src/data/context.rs
@@ -1,0 +1,6 @@
+use sqlx::SqlitePool;
+
+pub struct DirectoryContext {
+    pub address: String,
+    pub database_pool: SqlitePool,
+}

--- a/manager-rs/directory-service/src/data/context.rs
+++ b/manager-rs/directory-service/src/data/context.rs
@@ -1,6 +1,8 @@
 use sqlx::SqlitePool;
 
+/// Maintains all context for the directory service.
+#[derive(Debug)]
 pub struct DirectoryContext {
-    pub address: String,
+    pub host_address: String,
     pub database_pool: SqlitePool,
 }

--- a/manager-rs/directory-service/src/data/error.rs
+++ b/manager-rs/directory-service/src/data/error.rs
@@ -1,5 +1,3 @@
-use std::array::TryFromSliceError;
-
 use sqlx::Error as SqlxError;
 use thiserror::Error;
 

--- a/manager-rs/directory-service/src/data/error.rs
+++ b/manager-rs/directory-service/src/data/error.rs
@@ -6,20 +6,8 @@ use thiserror::Error;
 /// General error type for directory service failures
 #[derive(Error, Debug)]
 pub enum DirectoryError {
-    #[error("Not found error -- {0}")]
-    NotFoundError(String),
-
-    #[error("Config error -- {0}")]
-    ConfigError(String),
-
-    #[error("Data error -- {0}")]
-    DataError(String),
-
     #[error("Database error -- {0}")]
     DatabaseError(#[from] SqlxError),
-
-    #[error("Conversion error -- {0}")]
-    ConversionError(#[from] TryFromSliceError),
 
     #[error("Invalid access -- {0}")]
     InvalidAccess(String),

--- a/manager-rs/directory-service/src/data/error.rs
+++ b/manager-rs/directory-service/src/data/error.rs
@@ -20,4 +20,7 @@ pub enum DirectoryError {
 
     #[error("Conversion error -- {0}")]
     ConversionError(#[from] TryFromSliceError),
+
+    #[error("Invalid access -- {0}")]
+    InvalidAccess(String),
 }

--- a/manager-rs/directory-service/src/data/error.rs
+++ b/manager-rs/directory-service/src/data/error.rs
@@ -1,0 +1,23 @@
+use std::array::TryFromSliceError;
+
+use sqlx::Error as SqlxError;
+use thiserror::Error;
+
+/// General error type for directory service failures
+#[derive(Error, Debug)]
+pub enum DirectoryError {
+    #[error("Not found error -- {0}")]
+    NotFoundError(String),
+
+    #[error("Config error -- {0}")]
+    ConfigError(String),
+
+    #[error("Data error -- {0}")]
+    DataError(String),
+
+    #[error("Database error -- {0}")]
+    DatabaseError(#[from] SqlxError),
+
+    #[error("Conversion error -- {0}")]
+    ConversionError(#[from] TryFromSliceError),
+}

--- a/manager-rs/directory-service/src/data/error.rs
+++ b/manager-rs/directory-service/src/data/error.rs
@@ -9,4 +9,7 @@ pub enum DirectoryError {
 
     #[error("Invalid access -- {0}")]
     InvalidAccess(String),
+
+    #[error("Config error -- {0}")]
+    ConfigError(String),
 }

--- a/manager-rs/directory-service/src/data/mod.rs
+++ b/manager-rs/directory-service/src/data/mod.rs
@@ -1,0 +1,1 @@
+pub mod error;

--- a/manager-rs/directory-service/src/data/mod.rs
+++ b/manager-rs/directory-service/src/data/mod.rs
@@ -1,1 +1,2 @@
+pub mod context;
 pub mod error;

--- a/manager-rs/directory-service/src/data/mod.rs
+++ b/manager-rs/directory-service/src/data/mod.rs
@@ -1,2 +1,4 @@
+pub mod config;
 pub mod context;
 pub mod error;
+pub mod opt;

--- a/manager-rs/directory-service/src/data/opt.rs
+++ b/manager-rs/directory-service/src/data/opt.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Directory Service",
+    about = "An instance of the Directory Service"
+)]
+pub struct DirectoryOpt {
+    /// Yaml config file path
+    #[structopt(parse(from_os_str))]
+    pub config_path: PathBuf,
+}

--- a/manager-rs/directory-service/src/database/backups.rs
+++ b/manager-rs/directory-service/src/database/backups.rs
@@ -80,7 +80,7 @@ mod tests {
     use sqlx::{Row, SqlitePool};
     use tempfile::{tempdir, TempDir};
 
-    use crate::database::{backups, general, users, networks};
+    use crate::database::{backups, general, networks, users};
 
     fn gen_name() -> String {
         let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();

--- a/manager-rs/directory-service/src/database/backups.rs
+++ b/manager-rs/directory-service/src/database/backups.rs
@@ -157,7 +157,7 @@ mod tests {
 
         transaction.commit().await.unwrap();
     }
-    
+
     #[tokio::test]
     async fn test_remove() {
         let (pool, _dir) = init().await;

--- a/manager-rs/directory-service/src/database/backups.rs
+++ b/manager-rs/directory-service/src/database/backups.rs
@@ -1,0 +1,164 @@
+use sqlx::sqlite::{SqlitePool, SqliteRow};
+use sqlx::Error as SqlxError;
+use sqlx::{Sqlite, Transaction};
+
+use crate::data::error::DirectoryError;
+
+/// Creates the backup networks table if it does not exist already.
+/// Contains all networks that are used as a backup for this network
+pub async fn init_table(pool: &SqlitePool) -> Result<(), DirectoryError> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS backups_directory_table (
+            user_id TEXT NOT NULL,
+            backup_network_id TEXT NOT NULL,
+            PRIMARY KEY (user_id, backup_network_id)
+        );",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/* Queries */
+
+/// Adds a user with a backup network.
+pub async fn add(
+    transaction: &mut Transaction<'_, Sqlite>,
+    user_id: &str,
+    home_network_id: &str,
+) -> Result<(), SqlxError> {
+    sqlx::query(
+        "INSERT INTO backups_directory_table
+        VALUES ($1,$2)",
+    )
+    .bind(user_id)
+    .bind(home_network_id)
+    .execute(transaction)
+    .await?;
+
+    Ok(())
+}
+
+/// Gets all of the backup networks for a user.
+pub async fn get(
+    transaction: &mut Transaction<'_, Sqlite>,
+    user_id: &str,
+) -> Result<Vec<SqliteRow>, SqlxError> {
+    Ok(sqlx::query(
+        "SELECT * FROM backups_directory_table
+        WHERE user_id=$1;",
+    )
+    .bind(user_id)
+    .fetch_all(transaction)
+    .await?)
+}
+
+/// Removes all backup networks for a user.
+pub async fn remove(
+    transaction: &mut Transaction<'_, Sqlite>,
+    user_id: &str,
+) -> Result<(), SqlxError> {
+    sqlx::query(
+        "DELETE FROM backups_directory_table
+        WHERE user_info_id=$1",
+    )
+    .bind(user_id)
+    .execute(transaction)
+    .await?;
+
+    Ok(())
+}
+
+/* Testing */
+
+#[cfg(test)]
+mod tests {
+    use rand::distributions::Alphanumeric;
+    use rand::{thread_rng, Rng};
+    use sqlx::{Row, SqlitePool};
+    use tempfile::{tempdir, TempDir};
+
+    use crate::database::{backups, general};
+
+    fn gen_name() -> String {
+        let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
+
+        format!("sqlite_{}.db", s)
+    }
+
+    async fn init() -> (SqlitePool, TempDir) {
+        let dir = tempdir().unwrap();
+        let path = String::from(dir.path().join(gen_name()).to_str().unwrap());
+        println!("Building temporary db: {}", path);
+
+        let pool = general::build_pool(&path).await.unwrap();
+        backups::init_table(&pool).await.unwrap();
+
+        (pool, dir)
+    }
+
+    #[tokio::test]
+    async fn test_db_init() {
+        init().await;
+    }
+
+    #[tokio::test]
+    async fn test_add() {
+        let (pool, _dir) = init().await;
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            backups::add(
+                &mut transaction,
+                &format!("test_user_id_{}", row),
+                &format!("test_network_id_{}", row),
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+    }
+
+    /// Tests that get works
+    #[tokio::test]
+    async fn test_get() {
+        let (pool, _dir) = init().await;
+
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            backups::add(
+                &mut transaction,
+                &format!("test_user_id_0"),
+                &format!("test_network_id_{}", row),
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        let res = backups::get(
+            &mut transaction,
+            &format!("test_user_id_0"),
+        )
+        .await
+        .unwrap();
+
+        let mut xres = Vec::new();
+
+        for i in 0..num_rows {
+            xres.push(format!("test_network_id_{}", i));
+        }
+
+        for row in res {
+            xres.retain(|x| x != row.get_unchecked::<&str, &str>("backup_network_id"));
+        }
+
+        assert!(xres.is_empty());
+
+        transaction.commit().await.unwrap();
+    }
+}

--- a/manager-rs/directory-service/src/database/backups.rs
+++ b/manager-rs/directory-service/src/database/backups.rs
@@ -140,12 +140,9 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut transaction = pool.begin().await.unwrap();
-        let res = backups::get(
-            &mut transaction,
-            &format!("test_user_id_0"),
-        )
-        .await
-        .unwrap();
+        let res = backups::get(&mut transaction, &format!("test_user_id_0"))
+            .await
+            .unwrap();
 
         let mut xres = Vec::new();
 

--- a/manager-rs/directory-service/src/database/backups.rs
+++ b/manager-rs/directory-service/src/database/backups.rs
@@ -25,14 +25,14 @@ pub async fn init_table(pool: &SqlitePool) -> Result<(), DirectoryError> {
 pub async fn add(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
-    home_network_id: &str,
+    backup_network_id: &str,
 ) -> Result<(), SqlxError> {
     sqlx::query(
         "INSERT INTO backups_directory_table
         VALUES ($1,$2)",
     )
     .bind(user_id)
-    .bind(home_network_id)
+    .bind(backup_network_id)
     .execute(transaction)
     .await?;
 

--- a/manager-rs/directory-service/src/database/general.rs
+++ b/manager-rs/directory-service/src/database/general.rs
@@ -1,0 +1,61 @@
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+
+use crate::data::error::DirectoryError;
+use crate::database;
+
+/// Constructs the sqlite pool for running queries.
+pub async fn build_pool(database_path: &str) -> Result<SqlitePool, DirectoryError> {
+    Ok(SqlitePoolOptions::new()
+        .max_connections(10)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .create_if_missing(true)
+                .filename(database_path),
+        )
+        .await?)
+}
+
+/// Builds the database connection pool.
+/// Creates the database and tables if they don't exist.
+pub async fn database_init(database_path: &str) -> Result<SqlitePool, DirectoryError> {
+    let pool: SqlitePool = database::general::build_pool(database_path).await?;
+
+    database::networks::init_table(&pool).await?;
+    database::users::init_table(&pool).await?;
+
+    Ok(pool)
+}
+
+/* Testing */
+
+#[cfg(test)]
+mod tests {
+    use rand::distributions::Alphanumeric;
+    use rand::{thread_rng, Rng};
+    use sqlx::SqlitePool;
+    use tempfile::tempdir;
+
+    use crate::database;
+
+    fn gen_name() -> String {
+        let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
+
+        format!("sqlite_{}.db", s)
+    }
+
+    async fn init() -> SqlitePool {
+        let dir = tempdir().unwrap();
+        let path = String::from(dir.path().join(gen_name()).to_str().unwrap());
+        println!("Building temporary db: {}", path);
+
+        let pool = database::general::database_init(&path).await.unwrap();
+
+        pool
+    }
+
+    /// Test that db and table creation will work
+    #[tokio::test]
+    async fn test_db_init() {
+        init().await;
+    }
+}

--- a/manager-rs/directory-service/src/database/general.rs
+++ b/manager-rs/directory-service/src/database/general.rs
@@ -22,6 +22,7 @@ pub async fn database_init(database_path: &str) -> Result<SqlitePool, DirectoryE
 
     database::networks::init_table(&pool).await?;
     database::users::init_table(&pool).await?;
+    database::backups::init_table(&pool).await?;
 
     Ok(pool)
 }

--- a/manager-rs/directory-service/src/database/mod.rs
+++ b/manager-rs/directory-service/src/database/mod.rs
@@ -1,0 +1,3 @@
+pub mod backups;
+pub mod networks;
+pub mod users;

--- a/manager-rs/directory-service/src/database/mod.rs
+++ b/manager-rs/directory-service/src/database/mod.rs
@@ -1,3 +1,4 @@
 pub mod backups;
+pub mod general;
 pub mod networks;
 pub mod users;

--- a/manager-rs/directory-service/src/database/networks.rs
+++ b/manager-rs/directory-service/src/database/networks.rs
@@ -1,0 +1,194 @@
+use sqlx::sqlite::{SqlitePool, SqliteRow};
+use sqlx::Error as SqlxError;
+use sqlx::{Sqlite, Transaction};
+
+use crate::data::error::DirectoryError;
+
+/// Creates the backup networks table if it does not exist already.
+/// Contains all networks that are used as a backup for this network
+pub async fn init_table(pool: &SqlitePool) -> Result<(), DirectoryError> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS networks_directory_table (
+            network_id TEXT PRIMARY KEY,
+            address TEXT NOT NULL,
+            public_key BLOB NOT NULL
+        );",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/* Queries */
+
+/// Adds a network with its address and public key.
+pub async fn upsert(
+    transaction: &mut Transaction<'_, Sqlite>,
+    network_id: &str,
+    address: &str,
+    public_key: &[u8],
+) -> Result<(), SqlxError> {
+    sqlx::query(
+        "REPLACE INTO networks_directory_table
+        VALUES ($1,$2,$3)",
+    )
+    .bind(network_id)
+    .bind(address)
+    .bind(public_key)
+    .execute(transaction)
+    .await?;
+
+    Ok(())
+}
+
+/// Gets the address and public key of a given network.
+pub async fn get(
+    transaction: &mut Transaction<'_, Sqlite>,
+    network_id: &str,
+) -> Result<SqliteRow, SqlxError> {
+    Ok(sqlx::query(
+        "SELECT * FROM networks_directory_table
+        WHERE network_id=$1;",
+    )
+    .bind(network_id)
+    .fetch_one(transaction)
+    .await?)
+}
+
+/* Testing */
+
+#[cfg(test)]
+mod tests {
+    use rand::distributions::Alphanumeric;
+    use rand::{thread_rng, Rng};
+    use sqlx::{Row, SqlitePool};
+    use tempfile::{tempdir, TempDir};
+
+    use crate::database::{networks, general};
+
+    fn gen_name() -> String {
+        let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
+
+        format!("sqlite_{}.db", s)
+    }
+
+    async fn init() -> (SqlitePool, TempDir) {
+        let dir = tempdir().unwrap();
+        let path = String::from(dir.path().join(gen_name()).to_str().unwrap());
+        println!("Building temporary db: {}", path);
+
+        let pool = general::build_pool(&path).await.unwrap();
+        networks::init_table(&pool).await.unwrap();
+
+        (pool, dir)
+    }
+
+    #[tokio::test]
+    async fn test_db_init() {
+        init().await;
+    }
+
+    #[tokio::test]
+    async fn test_add() {
+        let (pool, _dir) = init().await;
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            networks::upsert(
+                &mut transaction,
+                &format!("test_network_id_{}", row),
+                &format!("test_address_{}", row),
+                &[0u8, 12],
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let (pool, _dir) = init().await;
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        networks::upsert(
+            &mut transaction,
+            "test_network_0",
+            "test_address_0",
+            &[0u8, 12],
+        )
+        .await
+        .unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        let res = networks::get(
+            &mut transaction,
+            "test_network_0",
+        )
+        .await
+        .unwrap();
+        assert_eq!("test_address_0", res.get_unchecked::<&str, &str>("address"));
+        assert_eq!(&[0u8, 12], res.get_unchecked::<&[u8], &str>("public_key"));
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        networks::upsert(
+            &mut transaction,
+            "test_network_0",
+            "test_address_0a",
+            &[1u8, 12],
+        )
+        .await
+        .unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        let res = networks::get(
+            &mut transaction,
+            "test_network_0",
+        )
+        .await
+        .unwrap();
+        assert_eq!("test_address_0a", res.get_unchecked::<&str, &str>("address"));
+        assert_eq!(&[1u8, 12], res.get_unchecked::<&[u8], &str>("public_key"));
+        transaction.commit().await.unwrap();
+    }
+
+    /// Tests that get works
+    #[tokio::test]
+    async fn test_get() {
+        let (pool, _dir) = init().await;
+
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            networks::upsert(
+                &mut transaction,
+                &format!("test_network_id_{}", row),
+                &format!("test_address_{}", row),
+                &[0u8, 12],
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            let res = networks::get(
+                &mut transaction,
+                &format!("test_network_id_{}", row),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(&format!("test_address_{}", row), res.get_unchecked::<&str, &str>("address"));
+            assert_eq!(&[0u8, 12], res.get_unchecked::<&[u8], &str>("public_key"));
+        }
+        transaction.commit().await.unwrap();
+    }
+}

--- a/manager-rs/directory-service/src/database/networks.rs
+++ b/manager-rs/directory-service/src/database/networks.rs
@@ -26,7 +26,7 @@ pub async fn upsert(
     transaction: &mut Transaction<'_, Sqlite>,
     network_id: &str,
     address: &str,
-    public_key: &[u8],
+    public_key: &Vec<u8>,
 ) -> Result<(), SqlxError> {
     sqlx::query(
         "REPLACE INTO networks_directory_table
@@ -99,7 +99,7 @@ mod tests {
                 &mut transaction,
                 &format!("test_network_id_{}", row),
                 &format!("test_address_{}", row),
-                &[0u8, 12],
+                &vec![0, 0, 0],
             )
             .await
             .unwrap();
@@ -117,7 +117,7 @@ mod tests {
             &mut transaction,
             "test_network_0",
             "test_address_0",
-            &[0u8, 12],
+            &vec![0, 0, 0],
         )
         .await
         .unwrap();
@@ -131,7 +131,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!("test_address_0", res.get_unchecked::<&str, &str>("address"));
-        assert_eq!(&[0u8, 12], res.get_unchecked::<&[u8], &str>("public_key"));
+        assert_eq!(vec![0, 0, 0], res.get_unchecked::<Vec<u8>, &str>("public_key"));
         transaction.commit().await.unwrap();
 
         let mut transaction = pool.begin().await.unwrap();
@@ -139,7 +139,7 @@ mod tests {
             &mut transaction,
             "test_network_0",
             "test_address_0a",
-            &[1u8, 12],
+            &vec![1, 1, 1],
         )
         .await
         .unwrap();
@@ -153,7 +153,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!("test_address_0a", res.get_unchecked::<&str, &str>("address"));
-        assert_eq!(&[1u8, 12], res.get_unchecked::<&[u8], &str>("public_key"));
+        assert_eq!(vec![1, 1, 1], res.get_unchecked::<Vec<u8>, &str>("public_key"));
         transaction.commit().await.unwrap();
     }
 
@@ -170,7 +170,7 @@ mod tests {
                 &mut transaction,
                 &format!("test_network_id_{}", row),
                 &format!("test_address_{}", row),
-                &[0u8, 12],
+                &vec![0, 0, 0],
             )
             .await
             .unwrap();
@@ -187,7 +187,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(&format!("test_address_{}", row), res.get_unchecked::<&str, &str>("address"));
-            assert_eq!(&[0u8, 12], res.get_unchecked::<&[u8], &str>("public_key"));
+            assert_eq!(vec![0, 0, 0], res.get_unchecked::<Vec<u8>, &str>("public_key"));
         }
         transaction.commit().await.unwrap();
     }

--- a/manager-rs/directory-service/src/database/networks.rs
+++ b/manager-rs/directory-service/src/database/networks.rs
@@ -64,7 +64,7 @@ mod tests {
     use sqlx::{Row, SqlitePool};
     use tempfile::{tempdir, TempDir};
 
-    use crate::database::{networks, general};
+    use crate::database::{general, networks};
 
     fn gen_name() -> String {
         let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
@@ -110,7 +110,6 @@ mod tests {
     #[tokio::test]
     async fn test_update() {
         let (pool, _dir) = init().await;
-        let num_rows = 10;
 
         let mut transaction = pool.begin().await.unwrap();
         networks::upsert(
@@ -124,14 +123,14 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut transaction = pool.begin().await.unwrap();
-        let res = networks::get(
-            &mut transaction,
-            "test_network_0",
-        )
-        .await
-        .unwrap();
+        let res = networks::get(&mut transaction, "test_network_0")
+            .await
+            .unwrap();
         assert_eq!("test_address_0", res.get_unchecked::<&str, &str>("address"));
-        assert_eq!(vec![0, 0, 0], res.get_unchecked::<Vec<u8>, &str>("public_key"));
+        assert_eq!(
+            vec![0, 0, 0],
+            res.get_unchecked::<Vec<u8>, &str>("public_key")
+        );
         transaction.commit().await.unwrap();
 
         let mut transaction = pool.begin().await.unwrap();
@@ -146,14 +145,17 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut transaction = pool.begin().await.unwrap();
-        let res = networks::get(
-            &mut transaction,
-            "test_network_0",
-        )
-        .await
-        .unwrap();
-        assert_eq!("test_address_0a", res.get_unchecked::<&str, &str>("address"));
-        assert_eq!(vec![1, 1, 1], res.get_unchecked::<Vec<u8>, &str>("public_key"));
+        let res = networks::get(&mut transaction, "test_network_0")
+            .await
+            .unwrap();
+        assert_eq!(
+            "test_address_0a",
+            res.get_unchecked::<&str, &str>("address")
+        );
+        assert_eq!(
+            vec![1, 1, 1],
+            res.get_unchecked::<Vec<u8>, &str>("public_key")
+        );
         transaction.commit().await.unwrap();
     }
 
@@ -179,15 +181,18 @@ mod tests {
 
         let mut transaction = pool.begin().await.unwrap();
         for row in 0..num_rows {
-            let res = networks::get(
-                &mut transaction,
-                &format!("test_network_id_{}", row),
-            )
-            .await
-            .unwrap();
+            let res = networks::get(&mut transaction, &format!("test_network_id_{}", row))
+                .await
+                .unwrap();
 
-            assert_eq!(&format!("test_address_{}", row), res.get_unchecked::<&str, &str>("address"));
-            assert_eq!(vec![0, 0, 0], res.get_unchecked::<Vec<u8>, &str>("public_key"));
+            assert_eq!(
+                &format!("test_address_{}", row),
+                res.get_unchecked::<&str, &str>("address")
+            );
+            assert_eq!(
+                vec![0, 0, 0],
+                res.get_unchecked::<Vec<u8>, &str>("public_key")
+            );
         }
         transaction.commit().await.unwrap();
     }

--- a/manager-rs/directory-service/src/database/users.rs
+++ b/manager-rs/directory-service/src/database/users.rs
@@ -1,0 +1,138 @@
+use sqlx::sqlite::{SqlitePool, SqliteRow};
+use sqlx::Error as SqlxError;
+use sqlx::{Sqlite, Transaction};
+
+use crate::data::error::DirectoryError;
+
+/// Creates the backup networks table if it does not exist already.
+/// Contains all networks that are used as a backup for this network
+pub async fn init_table(pool: &SqlitePool) -> Result<(), DirectoryError> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS users_directory_table (
+            user_id TEXT PRIMARY KEY,
+            home_network_id TEXT NOT NULL
+        );",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/* Queries */
+
+/// Adds a user with its home network.
+pub async fn add(
+    transaction: &mut Transaction<'_, Sqlite>,
+    user_id: &str,
+    home_network_id: &str,
+) -> Result<(), SqlxError> {
+    sqlx::query(
+        "INSERT INTO users_directory_table
+        VALUES ($1,$2)",
+    )
+    .bind(user_id)
+    .bind(home_network_id)
+    .execute(transaction)
+    .await?;
+
+    Ok(())
+}
+
+/// Gets the home network id of the user.
+pub async fn get(
+    transaction: &mut Transaction<'_, Sqlite>,
+    user_id: &str,
+) -> Result<SqliteRow, SqlxError> {
+    Ok(sqlx::query(
+        "SELECT * FROM users_directory_table
+        WHERE user_id=$1;",
+    )
+    .bind(user_id)
+    .fetch_one(transaction)
+    .await?)
+}
+
+/* Testing */
+
+#[cfg(test)]
+mod tests {
+    use rand::distributions::Alphanumeric;
+    use rand::{thread_rng, Rng};
+    use sqlx::{Row, SqlitePool};
+    use tempfile::{tempdir, TempDir};
+
+    use crate::database::{users, general};
+
+    fn gen_name() -> String {
+        let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
+
+        format!("sqlite_{}.db", s)
+    }
+
+    async fn init() -> (SqlitePool, TempDir) {
+        let dir = tempdir().unwrap();
+        let path = String::from(dir.path().join(gen_name()).to_str().unwrap());
+        println!("Building temporary db: {}", path);
+
+        let pool = general::build_pool(&path).await.unwrap();
+        users::init_table(&pool).await.unwrap();
+
+        (pool, dir)
+    }
+
+    #[tokio::test]
+    async fn test_db_init() {
+        init().await;
+    }
+
+    #[tokio::test]
+    async fn test_add() {
+        let (pool, _dir) = init().await;
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            users::add(
+                &mut transaction,
+                &format!("test_user_id_{}", row),
+                &format!("test_network_id_{}", row),
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+    }
+
+    /// Tests that get works
+    #[tokio::test]
+    async fn test_get() {
+        let (pool, _dir) = init().await;
+
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            users::add(
+                &mut transaction,
+                &format!("test_user_id_{}", row),
+                &format!("test_network_id_{}", row),
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            let res = users::get(
+                &mut transaction,
+                &format!("test_user_id_{}", row),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(&format!("test_network_id_{}", row), res.get_unchecked::<&str, &str>("home_network_id"));
+        }
+        transaction.commit().await.unwrap();
+    }
+}

--- a/manager-rs/directory-service/src/database/users.rs
+++ b/manager-rs/directory-service/src/database/users.rs
@@ -62,7 +62,7 @@ mod tests {
     use sqlx::{Row, SqlitePool};
     use tempfile::{tempdir, TempDir};
 
-    use crate::database::{general, users, networks};
+    use crate::database::{general, networks, users};
 
     fn gen_name() -> String {
         let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
@@ -116,7 +116,6 @@ mod tests {
         transaction.commit().await.unwrap();
     }
 
-    /// Tests that get works
     #[tokio::test]
     async fn test_get() {
         let (pool, _dir) = init().await;
@@ -159,9 +158,8 @@ mod tests {
         transaction.commit().await.unwrap();
     }
 
-    /// Tests that get works
     #[tokio::test]
-    async fn test_get_foreign_key_fail() {
+    async fn test_add_without_foreign_key_fail() {
         let (pool, _dir) = init().await;
 
         let mut transaction = pool.begin().await.unwrap();

--- a/manager-rs/directory-service/src/database/users.rs
+++ b/manager-rs/directory-service/src/database/users.rs
@@ -61,7 +61,7 @@ mod tests {
     use sqlx::{Row, SqlitePool};
     use tempfile::{tempdir, TempDir};
 
-    use crate::database::{users, general};
+    use crate::database::{general, users};
 
     fn gen_name() -> String {
         let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
@@ -124,14 +124,14 @@ mod tests {
 
         let mut transaction = pool.begin().await.unwrap();
         for row in 0..num_rows {
-            let res = users::get(
-                &mut transaction,
-                &format!("test_user_id_{}", row),
-            )
-            .await
-            .unwrap();
+            let res = users::get(&mut transaction, &format!("test_user_id_{}", row))
+                .await
+                .unwrap();
 
-            assert_eq!(&format!("test_network_id_{}", row), res.get_unchecked::<&str, &str>("home_network_id"));
+            assert_eq!(
+                &format!("test_network_id_{}", row),
+                res.get_unchecked::<&str, &str>("home_network_id")
+            );
         }
         transaction.commit().await.unwrap();
     }

--- a/manager-rs/directory-service/src/main.rs
+++ b/manager-rs/directory-service/src/main.rs
@@ -1,6 +1,16 @@
+use std::sync::Arc;
+
 mod data;
 mod database;
 mod manager;
 mod rpc;
 
-fn main() {}
+#[tokio::main]
+async fn main() {
+    let context = Arc::new(data::context::DirectoryContext {
+        host_address: "127.0.0.1:8900".to_string(),
+        database_pool: database::general::database_init("./directory_sqlite.db").await.expect("Failed to initialize database"),
+    });
+
+    rpc::server::start_server(context).await;
+}

--- a/manager-rs/directory-service/src/main.rs
+++ b/manager-rs/directory-service/src/main.rs
@@ -3,6 +3,4 @@ mod database;
 mod manager;
 mod rpc;
 
-fn main() {
-
-}
+fn main() {}

--- a/manager-rs/directory-service/src/main.rs
+++ b/manager-rs/directory-service/src/main.rs
@@ -1,16 +1,51 @@
-use std::sync::Arc;
-
 mod data;
 mod database;
 mod manager;
 mod rpc;
 
+use std::{path::PathBuf, sync::Arc};
+use structopt::StructOpt;
+
+use data::{
+    config::DirectoryConfig, context::DirectoryContext, error::DirectoryError, opt::DirectoryOpt,
+};
+
 #[tokio::main]
 async fn main() {
-    let context = Arc::new(data::context::DirectoryContext {
-        host_address: "127.0.0.1:8900".to_string(),
-        database_pool: database::general::database_init("./directory_sqlite.db").await.expect("Failed to initialize database"),
-    });
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let context = build_context(DirectoryOpt::from_args())
+        .await
+        .expect("Failed to generate context");
 
     rpc::server::start_server(context).await;
+}
+
+async fn build_context(
+    directory_opt: DirectoryOpt,
+) -> Result<Arc<DirectoryContext>, DirectoryError> {
+    let config = build_config(directory_opt.config_path)?;
+
+    Ok(Arc::new(data::context::DirectoryContext {
+        host_address: config.host_address,
+        database_pool: database::general::database_init(&config.database_path).await?,
+    }))
+}
+
+fn build_config(yaml_path: PathBuf) -> Result<DirectoryConfig, DirectoryError> {
+    match std::fs::read_to_string(yaml_path) {
+        Ok(yaml_string) => match serde_yaml::from_str(&yaml_string) {
+            Ok(config) => Ok(config),
+            Err(e) => Err(DirectoryError::ConfigError(format!(
+                "Config contents invalid: {}",
+                e
+            ))),
+        },
+        Err(e) => Err(DirectoryError::ConfigError(format!(
+            "Failed to open config file: {}",
+            e
+        ))),
+    }
 }

--- a/manager-rs/directory-service/src/main.rs
+++ b/manager-rs/directory-service/src/main.rs
@@ -1,0 +1,7 @@
+mod data;
+mod database;
+mod rpc;
+
+fn main() {
+
+}

--- a/manager-rs/directory-service/src/main.rs
+++ b/manager-rs/directory-service/src/main.rs
@@ -1,5 +1,6 @@
 mod data;
 mod database;
+mod manager;
 mod rpc;
 
 fn main() {

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -1,4 +1,4 @@
-use crate::data::error::DirectoryError;
+use crate::data::{context::DirectoryContext, error::DirectoryError};
 
 /*  Manager handles all functionality of the directory service.
  *  Shares a 1:1 relation with the RPC handler.
@@ -7,6 +7,7 @@ use crate::data::error::DirectoryError;
 /// Registers a network with the directory.
 /// Stores the networks address and public key.
 pub async fn register(
+    context: DirectoryContext,
     network_id: &str,
     address: &str,
     public_key: &Vec<u8>,
@@ -16,13 +17,19 @@ pub async fn register(
 
 /// Looks up a network by id and checks if it has been registered.
 /// Returns the address and public key of the network.
-pub async fn lookup_network(network_id: &str) -> Result<(String, Vec<u8>), DirectoryError> {
+pub async fn lookup_network(
+    context: DirectoryContext,
+    network_id: &str,
+) -> Result<(String, Vec<u8>), DirectoryError> {
     todo!()
 }
 
 /// Looks up a user by id.
 /// Returns the home network id and set of backup network ids.
-pub async fn lookup_user(user_id: &str) -> Result<(String, Vec<String>), DirectoryError> {
+pub async fn lookup_user(
+    context: DirectoryContext,
+    user_id: &str,
+) -> Result<(String, Vec<String>), DirectoryError> {
     todo!()
 }
 
@@ -32,6 +39,7 @@ pub async fn lookup_user(user_id: &str) -> Result<(String, Vec<String>), Directo
 /// If the user already exists, the home network must be the owner
 /// and the user info will be updated.
 pub async fn upsert_user(
+    context: DirectoryContext,
     user_id: &str,
     home_network_id: &str,
     backup_network_ids: Vec<&str>,

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -6,19 +6,19 @@ use crate::data::error::DirectoryError;
 
 /// Registers a network with the directory.
 /// Stores the networks address and public key.
-pub async fn register(network_id: String, address: String, public_key: Vec<u8>) -> Result<(), DirectoryError> {
+pub async fn register(network_id: &str, address: &str, public_key: &Vec<u8>) -> Result<(), DirectoryError> {
     todo!()
 }
 
 /// Looks up a network by id and checks if it has been registered.
 /// Returns the address and public key of the network.
-pub async fn lookup_network(network_id: String) -> Result<(String, Vec<u8>), DirectoryError> {
+pub async fn lookup_network(network_id: &str) -> Result<(String, Vec<u8>), DirectoryError> {
     todo!()
 }
 
 /// Looks up a user by id.
 /// Returns the home network id and set of backup network ids.
-pub async fn lookup_user(user_id: String) -> Result<(String, Vec<String>), DirectoryError> {
+pub async fn lookup_user(user_id: &str) -> Result<(String, Vec<String>), DirectoryError> {
     todo!()
 }
 
@@ -27,6 +27,6 @@ pub async fn lookup_user(user_id: String) -> Result<(String, Vec<String>), Direc
 /// If the user does not exist, the home network become the owner.
 /// If the user already exists, the home network must be the owner
 /// and the user info will be updated.
-pub async fn upsert_user(user_id: String, home_network_id: String, backup_network_ids: Vec<String>) {
+pub async fn upsert_user(user_id: &str, home_network_id: &str, backup_network_ids: Vec<&str>) {
     todo!()
 }

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use sqlx::sqlite::SqliteRow;
 use sqlx::Row;
 
@@ -11,7 +13,7 @@ use crate::database;
 /// Registers a network with the directory.
 /// Stores the networks address and public key.
 pub async fn register(
-    context: DirectoryContext,
+    context: Arc<DirectoryContext>,
     network_id: &str,
     address: &str,
     public_key: &Vec<u8>,
@@ -28,7 +30,7 @@ pub async fn register(
 /// Looks up a network by id and checks if it has been registered.
 /// Returns the address and public key of the network.
 pub async fn lookup_network(
-    context: DirectoryContext,
+    context: Arc<DirectoryContext>,
     network_id: &str,
 ) -> Result<(String, Vec<u8>), DirectoryError> {
     tracing::info!("Looup network called: {:?}", network_id);
@@ -45,7 +47,7 @@ pub async fn lookup_network(
 /// Looks up a user by id.
 /// Returns the home network id and set of backup network ids.
 pub async fn lookup_user(
-    context: DirectoryContext,
+    context: Arc<DirectoryContext>,
     user_id: &str,
 ) -> Result<(String, Vec<String>), DirectoryError> {
     tracing::info!("Looup user called: {:?}", user_id);
@@ -69,7 +71,7 @@ pub async fn lookup_user(
 /// If the user already exists, the home network must be the owner
 /// and the user info will be updated.
 pub async fn upsert_user(
-    context: DirectoryContext,
+    context: Arc<DirectoryContext>,
     user_id: &str,
     home_network_id: &str,
     backup_network_ids: Vec<&str>,

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -1,6 +1,4 @@
 use std::sync::Arc;
-
-use sqlx::sqlite::SqliteRow;
 use sqlx::Row;
 
 use crate::data::{context::DirectoryContext, error::DirectoryError};
@@ -74,7 +72,7 @@ pub async fn upsert_user(
     context: Arc<DirectoryContext>,
     user_id: &str,
     home_network_id: &str,
-    backup_network_ids: Vec<&str>,
+    backup_network_ids: &Vec<String>,
 ) -> Result<(), DirectoryError> {
     tracing::info!("Register called: {:?}-{:?}-{:?}", user_id, home_network_id, backup_network_ids);
 

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -31,6 +31,10 @@ pub async fn lookup_user(user_id: &str) -> Result<(String, Vec<String>), Directo
 /// If the user does not exist, the home network become the owner.
 /// If the user already exists, the home network must be the owner
 /// and the user info will be updated.
-pub async fn upsert_user(user_id: &str, home_network_id: &str, backup_network_ids: Vec<&str>) {
+pub async fn upsert_user(
+    user_id: &str,
+    home_network_id: &str,
+    backup_network_ids: Vec<&str>,
+) -> Result<(), DirectoryError> {
     todo!()
 }

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use sqlx::Row;
+use std::sync::Arc;
 
 use crate::data::{context::DirectoryContext, error::DirectoryError};
 use crate::database;
@@ -16,7 +16,12 @@ pub async fn register(
     address: &str,
     public_key: &Vec<u8>,
 ) -> Result<(), DirectoryError> {
-    tracing::info!("Register called: {:?}-{:?}-{:?}", network_id, address, public_key);
+    tracing::info!(
+        "Register called: {:?}-{:?}-{:?}",
+        network_id,
+        address,
+        public_key
+    );
 
     let mut transaction = context.database_pool.begin().await?;
     database::networks::upsert(&mut transaction, network_id, address, public_key).await?;
@@ -32,7 +37,7 @@ pub async fn lookup_network(
     network_id: &str,
 ) -> Result<(String, Vec<u8>), DirectoryError> {
     tracing::info!("Looup network called: {:?}", network_id);
-    
+
     let mut transaction = context.database_pool.begin().await?;
     let row = database::networks::get(&mut transaction, network_id).await?;
     let address = row.try_get::<String, &str>("address")?;
@@ -74,7 +79,12 @@ pub async fn upsert_user(
     home_network_id: &str,
     backup_network_ids: &Vec<String>,
 ) -> Result<(), DirectoryError> {
-    tracing::info!("Register called: {:?}-{:?}-{:?}", user_id, home_network_id, backup_network_ids);
+    tracing::info!(
+        "Register called: {:?}-{:?}-{:?}",
+        user_id,
+        home_network_id,
+        backup_network_ids
+    );
 
     let mut transaction = context.database_pool.begin().await?;
 
@@ -82,7 +92,9 @@ pub async fn upsert_user(
         if home_network_id == row.try_get::<String, &str>("home_network_id")? {
             database::backups::remove(&mut transaction, user_id).await?;
         } else {
-            return Err(DirectoryError::InvalidAccess("User owned by another network".to_string()));
+            return Err(DirectoryError::InvalidAccess(
+                "User owned by another network".to_string(),
+            ));
         }
     } else {
         database::users::add(&mut transaction, user_id, home_network_id).await?;

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -1,0 +1,32 @@
+use crate::data::error::DirectoryError;
+
+/*  Manager handles all functionality of the directory service.
+ *  Shares a 1:1 relation with the RPC handler.
+ */
+
+/// Registers a network with the directory.
+/// Stores the networks address and public key.
+pub async fn register(network_id: String, address: String, public_key: Vec<u8>) -> Result<(), DirectoryError> {
+    todo!()
+}
+
+/// Looks up a network by id and checks if it has been registered.
+/// Returns the address and public key of the network.
+pub async fn lookup_network(network_id: String) -> Result<(String, Vec<u8>), DirectoryError> {
+    todo!()
+}
+
+/// Looks up a user by id.
+/// Returns the home network id and set of backup network ids.
+pub async fn lookup_user(user_id: String) -> Result<(String, Vec<String>), DirectoryError> {
+    todo!()
+}
+
+/// Stores the user with the provided home network and set of
+/// backup networks.
+/// If the user does not exist, the home network become the owner.
+/// If the user already exists, the home network must be the owner
+/// and the user info will be updated.
+pub async fn upsert_user(user_id: String, home_network_id: String, backup_network_ids: Vec<String>) {
+    todo!()
+}

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -6,7 +6,11 @@ use crate::data::error::DirectoryError;
 
 /// Registers a network with the directory.
 /// Stores the networks address and public key.
-pub async fn register(network_id: &str, address: &str, public_key: &Vec<u8>) -> Result<(), DirectoryError> {
+pub async fn register(
+    network_id: &str,
+    address: &str,
+    public_key: &Vec<u8>,
+) -> Result<(), DirectoryError> {
     todo!()
 }
 

--- a/manager-rs/directory-service/src/rpc/handler.rs
+++ b/manager-rs/directory-service/src/rpc/handler.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use crate::manager;
 use crate::data::context::DirectoryContext;
+use crate::manager;
 use crate::rpc::directory_service::directory_server::Directory;
 use crate::rpc::directory_service::{
     LookupUserReq, LookupUserResp, LooukupNetworkReq, LooukupNetworkResp, RegisterReq,
@@ -20,10 +20,17 @@ impl Directory for DirectoryHandler {
         request: tonic::Request<RegisterReq>,
     ) -> Result<tonic::Response<RegisterResp>, tonic::Status> {
         tracing::info!("New request: {:?}", request);
-        
+
         let content = request.into_inner();
-        
-        match manager::register(self.context.clone(), &content.network_id, &content.address, &content.public_key).await {
+
+        match manager::register(
+            self.context.clone(),
+            &content.network_id,
+            &content.address,
+            &content.public_key,
+        )
+        .await
+        {
             Ok(()) => Ok(tonic::Response::new(RegisterResp {})),
             Err(e) => {
                 tracing::warn!("Request failed: {:?}", e);
@@ -37,11 +44,14 @@ impl Directory for DirectoryHandler {
         request: tonic::Request<LooukupNetworkReq>,
     ) -> Result<tonic::Response<LooukupNetworkResp>, tonic::Status> {
         tracing::info!("New request: {:?}", request);
-        
+
         let content = request.into_inner();
-        
+
         match manager::lookup_network(self.context.clone(), &content.network_id).await {
-            Ok((address, public_key)) => Ok(tonic::Response::new(LooukupNetworkResp { address, public_key })),
+            Ok((address, public_key)) => Ok(tonic::Response::new(LooukupNetworkResp {
+                address,
+                public_key,
+            })),
             Err(e) => {
                 tracing::warn!("Request failed: {:?}", e);
                 Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
@@ -54,11 +64,14 @@ impl Directory for DirectoryHandler {
         request: tonic::Request<LookupUserReq>,
     ) -> Result<tonic::Response<LookupUserResp>, tonic::Status> {
         tracing::info!("New request: {:?}", request);
-        
+
         let content = request.into_inner();
-        
+
         match manager::lookup_user(self.context.clone(), &content.user_id).await {
-            Ok((home_network_id, backup_network_ids)) => Ok(tonic::Response::new(LookupUserResp { home_network_id, backup_network_ids })),
+            Ok((home_network_id, backup_network_ids)) => Ok(tonic::Response::new(LookupUserResp {
+                home_network_id,
+                backup_network_ids,
+            })),
             Err(e) => {
                 tracing::warn!("Request failed: {:?}", e);
                 Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
@@ -71,10 +84,17 @@ impl Directory for DirectoryHandler {
         request: tonic::Request<UpsertUserReq>,
     ) -> Result<tonic::Response<UpsertUserResp>, tonic::Status> {
         tracing::info!("New request: {:?}", request);
-        
+
         let content = request.into_inner();
-        
-        match manager::upsert_user(self.context.clone(), &content.user_id, &content.home_network_id, &content.backup_network_ids).await {
+
+        match manager::upsert_user(
+            self.context.clone(),
+            &content.user_id,
+            &content.home_network_id,
+            &content.backup_network_ids,
+        )
+        .await
+        {
             Ok(()) => Ok(tonic::Response::new(UpsertUserResp {})),
             Err(e) => {
                 tracing::warn!("Request failed: {:?}", e);

--- a/manager-rs/directory-service/src/rpc/handler.rs
+++ b/manager-rs/directory-service/src/rpc/handler.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
+use crate::manager;
 use crate::data::context::DirectoryContext;
-use crate::data::error::DirectoryError;
 use crate::rpc::directory_service::directory_server::Directory;
 use crate::rpc::directory_service::{
     LookupUserReq, LookupUserResp, LooukupNetworkReq, LooukupNetworkResp, RegisterReq,
@@ -19,27 +19,67 @@ impl Directory for DirectoryHandler {
         &self,
         request: tonic::Request<RegisterReq>,
     ) -> Result<tonic::Response<RegisterResp>, tonic::Status> {
-        todo!()
+        tracing::info!("New request: {:?}", request);
+        
+        let content = request.into_inner();
+        
+        match manager::register(self.context.clone(), &content.network_id, &content.address, &content.public_key).await {
+            Ok(()) => Ok(tonic::Response::new(RegisterResp {})),
+            Err(e) => {
+                tracing::warn!("Request failed: {:?}", e);
+                Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
+            }
+        }
     }
 
     async fn lookup_network(
         &self,
         request: tonic::Request<LooukupNetworkReq>,
     ) -> Result<tonic::Response<LooukupNetworkResp>, tonic::Status> {
-        todo!()
+        tracing::info!("New request: {:?}", request);
+        
+        let content = request.into_inner();
+        
+        match manager::lookup_network(self.context.clone(), &content.network_id).await {
+            Ok((address, public_key)) => Ok(tonic::Response::new(LooukupNetworkResp { address, public_key })),
+            Err(e) => {
+                tracing::warn!("Request failed: {:?}", e);
+                Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
+            }
+        }
     }
 
     async fn lookup_user(
         &self,
         request: tonic::Request<LookupUserReq>,
     ) -> Result<tonic::Response<LookupUserResp>, tonic::Status> {
-        todo!()
+        tracing::info!("New request: {:?}", request);
+        
+        let content = request.into_inner();
+        
+        match manager::lookup_user(self.context.clone(), &content.user_id).await {
+            Ok((home_network_id, backup_network_ids)) => Ok(tonic::Response::new(LookupUserResp { home_network_id, backup_network_ids })),
+            Err(e) => {
+                tracing::warn!("Request failed: {:?}", e);
+                Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
+            }
+        }
     }
 
     async fn upsert_user(
         &self,
         request: tonic::Request<UpsertUserReq>,
     ) -> Result<tonic::Response<UpsertUserResp>, tonic::Status> {
-        todo!()
+        tracing::info!("New request: {:?}", request);
+        
+        let content = request.into_inner();
+        
+        match manager::upsert_user(self.context.clone(), &content.user_id, &content.home_network_id, &content.backup_network_ids).await {
+            Ok(()) => Ok(tonic::Response::new(UpsertUserResp {})),
+            Err(e) => {
+                tracing::warn!("Request failed: {:?}", e);
+                Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
+            }
+        }
     }
 }

--- a/manager-rs/directory-service/src/rpc/handler.rs
+++ b/manager-rs/directory-service/src/rpc/handler.rs
@@ -8,7 +8,7 @@ use crate::rpc::directory_service::{
     RegisterResp, UpsertUserReq, UpsertUserResp,
 };
 
-/// Handles all RPC calls to the dAuth service.
+/// Handles all RPC calls to the directory service.
 pub struct DirectoryHandler {
     pub context: Arc<DirectoryContext>,
 }

--- a/manager-rs/directory-service/src/rpc/handler.rs
+++ b/manager-rs/directory-service/src/rpc/handler.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use crate::data::context::DirectoryContext;
 use crate::data::error::DirectoryError;
 use crate::rpc::directory_service::directory_server::Directory;
-use crate::rpc::directory_service::{RegisterReq, RegisterResp, LookupUserReq, LookupUserResp, LooukupNetworkReq, LooukupNetworkResp, UpsertUserReq, UpsertUserResp};
+use crate::rpc::directory_service::{
+    LookupUserReq, LookupUserResp, LooukupNetworkReq, LooukupNetworkResp, RegisterReq,
+    RegisterResp, UpsertUserReq, UpsertUserResp,
+};
 
 /// Handles all RPC calls to the dAuth service.
 pub struct DirectoryHandler {

--- a/manager-rs/directory-service/src/rpc/handler.rs
+++ b/manager-rs/directory-service/src/rpc/handler.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use crate::data::context::DirectoryContext;
+use crate::data::error::DirectoryError;
+use crate::rpc::directory_service::directory_server::Directory;
+use crate::rpc::directory_service::{RegisterReq, RegisterResp, LookupUserReq, LookupUserResp, LooukupNetworkReq, LooukupNetworkResp, UpsertUserReq, UpsertUserResp};
+
+/// Handles all RPC calls to the dAuth service.
+pub struct DirectoryHandler {
+    pub context: Arc<DirectoryContext>,
+}
+
+#[tonic::async_trait]
+impl Directory for DirectoryHandler {
+    async fn register(
+        &self,
+        request: tonic::Request<RegisterReq>,
+    ) -> Result<tonic::Response<RegisterResp>, tonic::Status> {
+        todo!()
+    }
+
+    async fn lookup_network(
+        &self,
+        request: tonic::Request<LooukupNetworkReq>,
+    ) -> Result<tonic::Response<LooukupNetworkResp>, tonic::Status> {
+        todo!()
+    }
+
+    async fn lookup_user(
+        &self,
+        request: tonic::Request<LookupUserReq>,
+    ) -> Result<tonic::Response<LookupUserResp>, tonic::Status> {
+        todo!()
+    }
+
+    async fn upsert_user(
+        &self,
+        request: tonic::Request<UpsertUserReq>,
+    ) -> Result<tonic::Response<UpsertUserResp>, tonic::Status> {
+        todo!()
+    }
+}

--- a/manager-rs/directory-service/src/rpc/mod.rs
+++ b/manager-rs/directory-service/src/rpc/mod.rs
@@ -1,0 +1,4 @@
+pub mod handler;
+pub mod directory_service {
+    tonic::include_proto!("dauth_directory");
+}

--- a/manager-rs/directory-service/src/rpc/mod.rs
+++ b/manager-rs/directory-service/src/rpc/mod.rs
@@ -1,4 +1,6 @@
 pub mod handler;
+pub mod server;
+
 pub mod directory_service {
     tonic::include_proto!("dauth_directory");
 }

--- a/manager-rs/directory-service/src/rpc/server.rs
+++ b/manager-rs/directory-service/src/rpc/server.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use tonic::transport::Server;
+
+use crate::rpc::directory_service::directory_server::DirectoryServer;
+use crate::data::context::DirectoryContext;
+use crate::rpc::handler::DirectoryHandler;
+
+#[tracing::instrument]
+pub async fn start_server(context: Arc<DirectoryContext>) {
+    tracing::info!("Hosting directory server on {}", context.host_address);
+
+    Server::builder()
+        .add_service(DirectoryServer::new(DirectoryHandler {
+            context: context.clone(),
+        }))
+        .serve(context.host_address.parse().unwrap())
+        .await
+        .unwrap();
+}

--- a/manager-rs/directory-service/src/rpc/server.rs
+++ b/manager-rs/directory-service/src/rpc/server.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use tonic::transport::Server;
 
-use crate::rpc::directory_service::directory_server::DirectoryServer;
 use crate::data::context::DirectoryContext;
+use crate::rpc::directory_service::directory_server::DirectoryServer;
 use crate::rpc::handler::DirectoryHandler;
 
 #[tracing::instrument]

--- a/protos/directory.proto
+++ b/protos/directory.proto
@@ -15,7 +15,7 @@ service Directory {
     // Looks up a specific network by its network id.
     // If the network has been registered, returns the corresponding 
     // address and public key.
-    rpc LooukupNetwork(LooukupNetworkReq) returns (LooukupNetworkResp);
+    rpc LookupNetwork(LooukupNetworkReq) returns (LooukupNetworkResp);
 
     // Looks up a specific user by its user id.
     // If the user exists, returns the corresponding home network id


### PR DESCRIPTION
Implemented directory service to handle simple directory service calls. Key points:
- Uses sqlite as the main data store
- Uses a basic config file with path as the command line argument
- Does virtually no authentication
- Does not yet incorporate timing delays for calls (can add to config later)
- Heavily based on dauth service, but much simpler