### PR TITLE
Devel rpc refactor

### DIFF
--- a/manager-rs/dauth-service/src/rpc/clients/backup_network.rs
+++ b/manager-rs/dauth-service/src/rpc/clients/backup_network.rs
@@ -1,13 +1,75 @@
 use std::sync::Arc;
 
+use auth_vector::types::{HresStar, Kseaf};
+
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;
 use crate::data::vector::AuthVectorRes;
+
+/// Request a network to become a backup network.
+pub async fn enroll_backup_prepare(
+    context: Arc<DauthContext>,
+    user_id: &str,
+    backup_network_id: &str,
+    address: &str,
+) -> Result<(), DauthError> {
+    todo!()
+}
+
+/// Send the set of initial vectors and key shares after
+/// a network has agreed to be a backup.
+pub async fn enroll_backup_commit(
+    context: Arc<DauthContext>,
+    vectors: Vec<AuthVectorRes>,
+    key_shares: Vec<(HresStar, Kseaf)>,
+    address: &str,
+) -> Result<(), DauthError> {
+    todo!()
+}
 
 /// Get an auth vector from one of a user's backup networks.
 pub async fn get_auth_vector(
     context: Arc<DauthContext>,
     user_id: &str,
+    address: &str,
+) -> Result<AuthVectorRes, DauthError> {
+    todo!()
+}
+
+/// Get a key share from one of a user's backup networks.
+pub async fn get_key_share(
+    context: Arc<DauthContext>,
+    xres_star_hash: HresStar,
+    res_star: Kseaf,
+    address: &str,
+) -> Result<Kseaf, DauthError> {
+    todo!()
+}
+
+/// Withdraws backup status from a backup network.
+pub async fn withdraw_backup(
+    context: Arc<DauthContext>,
+    user_id: &str,
+    backup_network_id: &str,
+    address: &str,
+) -> Result<(), DauthError> {
+    todo!()
+}
+
+/// Withdraws all matching shares from a backup network.
+pub async fn withdraw_shares(
+    context: Arc<DauthContext>,
+    xres_star_hashs: Vec<HresStar>,
+    address: &str,
+) -> Result<(), DauthError> {
+    todo!()
+}
+
+/// Sends a flood vector to a backup network.
+pub async fn flood_vector(
+    context: Arc<DauthContext>,
+    user_id: &str,
+    vector: AuthVectorRes,
     address: &str,
 ) -> Result<AuthVectorRes, DauthError> {
     todo!()

--- a/manager-rs/dauth-service/src/rpc/clients/directory.rs
+++ b/manager-rs/dauth-service/src/rpc/clients/directory.rs
@@ -7,9 +7,7 @@ use crate::data::error::DauthError;
 
 /// Registers this network with the directory service.
 /// Provides this network's id, address, and public key.
-pub async fn register(
-    context: Arc<DauthContext>,
-) -> Result<(), DauthError> {
+pub async fn register(context: Arc<DauthContext>) -> Result<(), DauthError> {
     todo!()
 }
 

--- a/manager-rs/dauth-service/src/rpc/clients/directory.rs
+++ b/manager-rs/dauth-service/src/rpc/clients/directory.rs
@@ -5,6 +5,14 @@ use ed25519_dalek::PublicKey;
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;
 
+/// Registers this network with the directory service.
+/// Provides this network's id, address, and public key.
+pub async fn register(
+    context: Arc<DauthContext>,
+) -> Result<(), DauthError> {
+    todo!()
+}
+
 /// Contacts directory service to find the address
 /// and public key of the provided network id
 /// Returns pair (address, public key)
@@ -22,5 +30,16 @@ pub async fn lookup_user(
     context: Arc<DauthContext>,
     user_id: &str,
 ) -> Result<(String, Vec<String>), DauthError> {
+    todo!()
+}
+
+/// Sends user info to the directory service.
+/// If the user doesn't exist, this network claims ownership.
+/// Otherwise, user info is updated iff this network owns the user.
+pub async fn upsert_user(
+    context: Arc<DauthContext>,
+    user_id: &str,
+    backup_network_ids: Vec<String>,
+) -> Result<(), DauthError> {
     todo!()
 }

--- a/manager-rs/dauth-service/src/rpc/clients/home_network.rs
+++ b/manager-rs/dauth-service/src/rpc/clients/home_network.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use auth_vector::types::{ResStar, HresStar, Kseaf};
+
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;
 use crate::data::vector::AuthVectorRes;
@@ -10,5 +12,15 @@ pub async fn get_auth_vector(
     user_id: &str,
     address: &str,
 ) -> Result<AuthVectorRes, DauthError> {
+    todo!()
+}
+
+/// Get the kseaf value at the end of an auth vector transaction.
+pub async fn get_confirm_key(
+    context: Arc<DauthContext>,
+    res_star: &ResStar,
+    xres_star_hash: &HresStar,
+    address: &str,
+) -> Result<Kseaf, DauthError> {
     todo!()
 }

--- a/manager-rs/dauth-service/src/rpc/clients/home_network.rs
+++ b/manager-rs/dauth-service/src/rpc/clients/home_network.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use auth_vector::types::{ResStar, HresStar, Kseaf};
+use auth_vector::types::{HresStar, Kseaf, ResStar};
 
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;

--- a/manager-rs/dauth-service/src/rpc/handlers/backup_network.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/backup_network.rs
@@ -1,153 +1,20 @@
 use std::sync::Arc;
 
-use auth_vector::types::ResStar;
-
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;
 use crate::data::signing::{self, SignPayloadType};
 use crate::data::vector::{AuthVectorReq, AuthVectorRes};
 use crate::manager;
+use crate::rpc::handlers::handler::DauthHandler;
 use crate::rpc::dauth::common::{AuthVector5G, UserIdKind};
-use crate::rpc::dauth::local::aka_confirm_resp;
-use crate::rpc::dauth::local::local_authentication_server::LocalAuthentication;
-use crate::rpc::dauth::local::{AkaConfirmReq, AkaConfirmResp, AkaVectorReq, AkaVectorResp};
-use crate::rpc::dauth::remote::{
-    backup_network_server::BackupNetwork, home_network_server::HomeNetwork,
-};
+use crate::rpc::dauth::remote::backup_network_server::BackupNetwork;
 use crate::rpc::dauth::remote::{delegated_auth_vector5_g, delegated_confirmation_share};
 use crate::rpc::dauth::remote::{
     DelegatedAuthVector5G, DelegatedConfirmationShare, EnrollBackupCommitReq,
     EnrollBackupCommitResp, EnrollBackupPrepareReq, EnrollBackupPrepareResp, FloodVectorReq,
-    FloodVectorResp, GetBackupAuthVectorReq, GetBackupAuthVectorResp, GetHomeAuthVectorReq,
-    GetHomeAuthVectorResp, GetHomeConfirmKeyReq, GetHomeConfirmKeyResp, GetKeyShareReq,
+    FloodVectorResp, GetBackupAuthVectorReq, GetBackupAuthVectorResp, GetKeyShareReq,
     GetKeyShareResp, WithdrawBackupReq, WithdrawBackupResp, WithdrawSharesReq, WithdrawSharesResp,
 };
-
-/// Handles all RPC calls to the dAuth service.
-pub struct DauthHandler {
-    pub context: Arc<DauthContext>,
-}
-
-#[tonic::async_trait]
-impl LocalAuthentication for DauthHandler {
-    /// Local request for a vector that will be used on this network.
-    /// No authentication is done.
-    async fn get_auth_vector(
-        &self,
-        request: tonic::Request<AkaVectorReq>,
-    ) -> Result<tonic::Response<AkaVectorResp>, tonic::Status> {
-        tracing::info!("Request: {:?}", request);
-
-        let av_request: AuthVectorReq;
-        match AuthVectorReq::from_req(request.into_inner()) {
-            Ok(req) => av_request = req,
-            Err(e) => return Err(tonic::Status::new(tonic::Code::Aborted, e.to_string())),
-        }
-
-        match manager::find_vector(self.context.clone(), &av_request).await {
-            Ok(av_result) => {
-                tracing::info!("Returning result: {:?}", av_result);
-                Ok(tonic::Response::new(av_result.to_resp()))
-            }
-            Err(e) => {
-                tracing::error!("Error while handling request for {:?}: {}", av_request, e);
-                Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
-            }
-        }
-    }
-
-    /// Local request for to complete auth process for a vector.
-    /// No authentication is done.
-    async fn confirm_auth(
-        &self,
-        request: tonic::Request<AkaConfirmReq>,
-    ) -> Result<tonic::Response<AkaConfirmResp>, tonic::Status> {
-        tracing::info!("Request: {:?}", request);
-
-        let res_star = request.into_inner().res_star;
-        let res_star: auth_vector::types::ResStar =
-            res_star.try_into().or_else(|_e: Vec<u8>| {
-                Err(tonic::Status::new(
-                    tonic::Code::OutOfRange,
-                    "Unable to parse res_star",
-                ))
-            })?;
-
-        let kseaf = manager::confirm_auth_vector(self.context.clone(), res_star)
-            .await
-            .or_else(|e| Err(tonic::Status::new(tonic::Code::NotFound, e.to_string())))?;
-
-        let response_payload = AkaConfirmResp {
-            error: aka_confirm_resp::ErrorKind::NoError as i32,
-            kseaf: kseaf.to_vec(),
-        };
-
-        Ok(tonic::Response::new(response_payload))
-    }
-}
-
-#[tonic::async_trait]
-impl HomeNetwork for DauthHandler {
-    /// Remote request for a vector that will be generated on this network.
-    /// Checks for proper authentication and reputation.
-    async fn get_auth_vector(
-        &self,
-        request: tonic::Request<GetHomeAuthVectorReq>,
-    ) -> Result<tonic::Response<GetHomeAuthVectorResp>, tonic::Status> {
-        tracing::info!("Request: {:?}", request);
-
-        let message = request
-            .into_inner()
-            .message
-            .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "No message received"))?;
-
-        let verify_result =
-            signing::verify_message(self.context.clone(), &message).or_else(|e| {
-                Err(tonic::Status::new(
-                    tonic::Code::Unauthenticated,
-                    format!("Failed to verify message: {}", e),
-                ))
-            })?;
-
-        match DauthHandler::get_home_auth_vector_hlp(self.context.clone(), verify_result).await {
-            Ok(result) => Ok(result),
-            Err(e) => Err(tonic::Status::new(
-                tonic::Code::Aborted,
-                format!("Error while handling request: {}", e),
-            )),
-        }
-    }
-
-    /// Remote request for to complete auth process for a vector.
-    /// Checks for proper authentication.
-    async fn get_confirm_key(
-        &self,
-        request: tonic::Request<GetHomeConfirmKeyReq>,
-    ) -> Result<tonic::Response<GetHomeConfirmKeyResp>, tonic::Status> {
-        tracing::info!("Request: {:?}", request);
-
-        let message = request
-            .into_inner()
-            .message
-            .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "No message received"))?;
-
-        let verify_result =
-            signing::verify_message(self.context.clone(), &message).or_else(|e| {
-                Err(tonic::Status::new(
-                    tonic::Code::Unauthenticated,
-                    format!("Failed to verify message: {}", e),
-                ))
-            })?;
-
-        match DauthHandler::get_confirm_key_hlp(self.context.clone(), verify_result).await {
-            Ok(result) => Ok(result),
-            Err(e) => Err(tonic::Status::new(
-                tonic::Code::Aborted,
-                format!("Error while handling request: {}", e),
-            )),
-        }
-    }
-}
 
 #[tonic::async_trait]
 impl BackupNetwork for DauthHandler {
@@ -406,68 +273,6 @@ impl DauthHandler {
     }
 
     /* Specific helpers */
-    async fn get_home_auth_vector_hlp(
-        context: Arc<DauthContext>,
-        verify_result: SignPayloadType,
-    ) -> Result<tonic::Response<GetHomeAuthVectorResp>, DauthError> {
-        if let SignPayloadType::GetHomeAuthVectorReq(payload) = verify_result {
-            let user_id = std::str::from_utf8(payload.user_id.as_slice())?.to_string();
-
-            // TODO: Handle reputation
-
-            let av_result = manager::generate_auth_vector(
-                context.clone(),
-                &AuthVectorReq {
-                    user_id: user_id.to_string(),
-                },
-            )
-            .await?;
-
-            let payload = delegated_auth_vector5_g::Payload {
-                serving_network_id: context.local_context.id.clone(),
-                v: Some(AuthVector5G {
-                    rand: av_result.rand.to_vec(),
-                    xres_star_hash: av_result.xres_star_hash.to_vec(),
-                    autn: av_result.autn.to_vec(),
-                    seqnum: av_result.seqnum,
-                }),
-            };
-
-            Ok(tonic::Response::new(GetHomeAuthVectorResp {
-                vector: Some(DelegatedAuthVector5G {
-                    message: Some(signing::sign_message(
-                        context,
-                        signing::SignPayloadType::DelegatedAuthVector5G(payload),
-                    )),
-                }),
-            }))
-        } else {
-            Err(DauthError::InvalidMessageError(format!(
-                "Incorrect message type: {:?}",
-                verify_result
-            )))
-        }
-    }
-
-    async fn get_confirm_key_hlp(
-        context: Arc<DauthContext>,
-        verify_result: SignPayloadType,
-    ) -> Result<tonic::Response<GetHomeConfirmKeyResp>, DauthError> {
-        if let SignPayloadType::GetHomeConfirmKeyReq(payload) = verify_result {
-            let res_star: ResStar = payload.res_star.as_slice().try_into()?;
-
-            let kseaf = manager::confirm_auth_vector(context, res_star).await?;
-
-            Ok(tonic::Response::new(GetHomeConfirmKeyResp {
-                kseaf: kseaf.to_vec(),
-            }))
-        } else {
-            Err(DauthError::InvalidMessageError(format!(
-                "Incorrect message type: {:?}",
-                verify_result
-            )))
-        }
-    }
 
     async fn enroll_backup_prepare_hlp(
         context: Arc<DauthContext>,

--- a/manager-rs/dauth-service/src/rpc/handlers/backup_network.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/backup_network.rs
@@ -5,7 +5,6 @@ use crate::data::error::DauthError;
 use crate::data::signing::{self, SignPayloadType};
 use crate::data::vector::{AuthVectorReq, AuthVectorRes};
 use crate::manager;
-use crate::rpc::handlers::handler::DauthHandler;
 use crate::rpc::dauth::common::{AuthVector5G, UserIdKind};
 use crate::rpc::dauth::remote::backup_network_server::BackupNetwork;
 use crate::rpc::dauth::remote::{delegated_auth_vector5_g, delegated_confirmation_share};
@@ -15,6 +14,7 @@ use crate::rpc::dauth::remote::{
     FloodVectorResp, GetBackupAuthVectorReq, GetBackupAuthVectorResp, GetKeyShareReq,
     GetKeyShareResp, WithdrawBackupReq, WithdrawBackupResp, WithdrawSharesReq, WithdrawSharesResp,
 };
+use crate::rpc::handlers::handler::DauthHandler;
 
 #[tonic::async_trait]
 impl BackupNetwork for DauthHandler {

--- a/manager-rs/dauth-service/src/rpc/handlers/handler.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/handler.rs
@@ -1,8 +1,0 @@
-use std::sync::Arc;
-
-use crate::data::context::DauthContext;
-
-/// Handles all RPC calls to the dAuth service.
-pub struct DauthHandler {
-    pub context: Arc<DauthContext>,
-}

--- a/manager-rs/dauth-service/src/rpc/handlers/handler.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/handler.rs
@@ -1,0 +1,8 @@
+use std::sync::Arc;
+
+use crate::data::context::DauthContext;
+
+/// Handles all RPC calls to the dAuth service.
+pub struct DauthHandler {
+    pub context: Arc<DauthContext>,
+}

--- a/manager-rs/dauth-service/src/rpc/handlers/home_network.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/home_network.rs
@@ -14,10 +14,13 @@ use crate::rpc::dauth::remote::{
     DelegatedAuthVector5G, GetHomeAuthVectorReq, GetHomeAuthVectorResp, GetHomeConfirmKeyReq,
     GetHomeConfirmKeyResp,
 };
-use crate::rpc::handlers::handler::DauthHandler;
+
+pub struct HomeNetworkHandler {
+    pub context: Arc<DauthContext>,
+}
 
 #[tonic::async_trait]
-impl HomeNetwork for DauthHandler {
+impl HomeNetwork for HomeNetworkHandler {
     /// Remote request for a vector that will be generated on this network.
     /// Checks for proper authentication and reputation.
     async fn get_auth_vector(
@@ -39,7 +42,9 @@ impl HomeNetwork for DauthHandler {
                 ))
             })?;
 
-        match DauthHandler::get_home_auth_vector_hlp(self.context.clone(), verify_result).await {
+        match HomeNetworkHandler::get_home_auth_vector_hlp(self.context.clone(), verify_result)
+            .await
+        {
             Ok(result) => Ok(result),
             Err(e) => Err(tonic::Status::new(
                 tonic::Code::Aborted,
@@ -69,7 +74,7 @@ impl HomeNetwork for DauthHandler {
                 ))
             })?;
 
-        match DauthHandler::get_confirm_key_hlp(self.context.clone(), verify_result).await {
+        match HomeNetworkHandler::get_confirm_key_hlp(self.context.clone(), verify_result).await {
             Ok(result) => Ok(result),
             Err(e) => Err(tonic::Status::new(
                 tonic::Code::Aborted,
@@ -79,7 +84,7 @@ impl HomeNetwork for DauthHandler {
     }
 }
 
-impl DauthHandler {
+impl HomeNetworkHandler {
     async fn get_home_auth_vector_hlp(
         context: Arc<DauthContext>,
         verify_result: SignPayloadType,

--- a/manager-rs/dauth-service/src/rpc/handlers/home_network.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/home_network.rs
@@ -1,0 +1,145 @@
+use std::sync::Arc;
+
+use auth_vector::types::ResStar;
+
+use crate::data::context::DauthContext;
+use crate::data::error::DauthError;
+use crate::data::signing::{self, SignPayloadType};
+use crate::data::vector::AuthVectorReq;
+use crate::manager;
+use crate::rpc::handlers::handler::DauthHandler;
+use crate::rpc::dauth::common::AuthVector5G;
+use crate::rpc::dauth::remote:: home_network_server::HomeNetwork;
+use crate::rpc::dauth::remote::delegated_auth_vector5_g;
+use crate::rpc::dauth::remote::{
+    DelegatedAuthVector5G, GetHomeAuthVectorReq,
+    GetHomeAuthVectorResp, GetHomeConfirmKeyReq, GetHomeConfirmKeyResp,
+};
+
+#[tonic::async_trait]
+impl HomeNetwork for DauthHandler {
+    /// Remote request for a vector that will be generated on this network.
+    /// Checks for proper authentication and reputation.
+    async fn get_auth_vector(
+        &self,
+        request: tonic::Request<GetHomeAuthVectorReq>,
+    ) -> Result<tonic::Response<GetHomeAuthVectorResp>, tonic::Status> {
+        tracing::info!("Request: {:?}", request);
+
+        let message = request
+            .into_inner()
+            .message
+            .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "No message received"))?;
+
+        let verify_result =
+            signing::verify_message(self.context.clone(), &message).or_else(|e| {
+                Err(tonic::Status::new(
+                    tonic::Code::Unauthenticated,
+                    format!("Failed to verify message: {}", e),
+                ))
+            })?;
+
+        match DauthHandler::get_home_auth_vector_hlp(self.context.clone(), verify_result).await {
+            Ok(result) => Ok(result),
+            Err(e) => Err(tonic::Status::new(
+                tonic::Code::Aborted,
+                format!("Error while handling request: {}", e),
+            )),
+        }
+    }
+
+    /// Remote request for to complete auth process for a vector.
+    /// Checks for proper authentication.
+    async fn get_confirm_key(
+        &self,
+        request: tonic::Request<GetHomeConfirmKeyReq>,
+    ) -> Result<tonic::Response<GetHomeConfirmKeyResp>, tonic::Status> {
+        tracing::info!("Request: {:?}", request);
+
+        let message = request
+            .into_inner()
+            .message
+            .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "No message received"))?;
+
+        let verify_result =
+            signing::verify_message(self.context.clone(), &message).or_else(|e| {
+                Err(tonic::Status::new(
+                    tonic::Code::Unauthenticated,
+                    format!("Failed to verify message: {}", e),
+                ))
+            })?;
+
+        match DauthHandler::get_confirm_key_hlp(self.context.clone(), verify_result).await {
+            Ok(result) => Ok(result),
+            Err(e) => Err(tonic::Status::new(
+                tonic::Code::Aborted,
+                format!("Error while handling request: {}", e),
+            )),
+        }
+    }
+}
+
+impl DauthHandler {
+    async fn get_home_auth_vector_hlp(
+        context: Arc<DauthContext>,
+        verify_result: SignPayloadType,
+    ) -> Result<tonic::Response<GetHomeAuthVectorResp>, DauthError> {
+        if let SignPayloadType::GetHomeAuthVectorReq(payload) = verify_result {
+            let user_id = std::str::from_utf8(payload.user_id.as_slice())?.to_string();
+
+            // TODO: Handle reputation
+
+            let av_result = manager::generate_auth_vector(
+                context.clone(),
+                &AuthVectorReq {
+                    user_id: user_id.to_string(),
+                },
+            )
+            .await?;
+
+            let payload = delegated_auth_vector5_g::Payload {
+                serving_network_id: context.local_context.id.clone(),
+                v: Some(AuthVector5G {
+                    rand: av_result.rand.to_vec(),
+                    xres_star_hash: av_result.xres_star_hash.to_vec(),
+                    autn: av_result.autn.to_vec(),
+                    seqnum: av_result.seqnum,
+                }),
+            };
+
+            Ok(tonic::Response::new(GetHomeAuthVectorResp {
+                vector: Some(DelegatedAuthVector5G {
+                    message: Some(signing::sign_message(
+                        context,
+                        signing::SignPayloadType::DelegatedAuthVector5G(payload),
+                    )),
+                }),
+            }))
+        } else {
+            Err(DauthError::InvalidMessageError(format!(
+                "Incorrect message type: {:?}",
+                verify_result
+            )))
+        }
+    }
+
+    async fn get_confirm_key_hlp(
+        context: Arc<DauthContext>,
+        verify_result: SignPayloadType,
+    ) -> Result<tonic::Response<GetHomeConfirmKeyResp>, DauthError> {
+        if let SignPayloadType::GetHomeConfirmKeyReq(payload) = verify_result {
+            let res_star: ResStar = payload.res_star.as_slice().try_into()?;
+
+            let kseaf = manager::confirm_auth_vector(context, res_star).await?;
+
+            Ok(tonic::Response::new(GetHomeConfirmKeyResp {
+                kseaf: kseaf.to_vec(),
+            }))
+        } else {
+            Err(DauthError::InvalidMessageError(format!(
+                "Incorrect message type: {:?}",
+                verify_result
+            )))
+        }
+    }
+}

--- a/manager-rs/dauth-service/src/rpc/handlers/home_network.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/home_network.rs
@@ -7,14 +7,14 @@ use crate::data::error::DauthError;
 use crate::data::signing::{self, SignPayloadType};
 use crate::data::vector::AuthVectorReq;
 use crate::manager;
-use crate::rpc::handlers::handler::DauthHandler;
 use crate::rpc::dauth::common::AuthVector5G;
-use crate::rpc::dauth::remote:: home_network_server::HomeNetwork;
 use crate::rpc::dauth::remote::delegated_auth_vector5_g;
+use crate::rpc::dauth::remote::home_network_server::HomeNetwork;
 use crate::rpc::dauth::remote::{
-    DelegatedAuthVector5G, GetHomeAuthVectorReq,
-    GetHomeAuthVectorResp, GetHomeConfirmKeyReq, GetHomeConfirmKeyResp,
+    DelegatedAuthVector5G, GetHomeAuthVectorReq, GetHomeAuthVectorResp, GetHomeConfirmKeyReq,
+    GetHomeConfirmKeyResp,
 };
+use crate::rpc::handlers::handler::DauthHandler;
 
 #[tonic::async_trait]
 impl HomeNetwork for DauthHandler {

--- a/manager-rs/dauth-service/src/rpc/handlers/local_authentication.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/local_authentication.rs
@@ -1,0 +1,64 @@
+use crate::data::vector::AuthVectorReq;
+use crate::manager;
+use crate::rpc::handlers::handler::DauthHandler;
+use crate::rpc::dauth::local::aka_confirm_resp;
+use crate::rpc::dauth::local::local_authentication_server::LocalAuthentication;
+use crate::rpc::dauth::local::{AkaConfirmReq, AkaConfirmResp, AkaVectorReq, AkaVectorResp};
+
+#[tonic::async_trait]
+impl LocalAuthentication for DauthHandler {
+    /// Local request for a vector that will be used on this network.
+    /// No authentication is done.
+    async fn get_auth_vector(
+        &self,
+        request: tonic::Request<AkaVectorReq>,
+    ) -> Result<tonic::Response<AkaVectorResp>, tonic::Status> {
+        tracing::info!("Request: {:?}", request);
+
+        let av_request: AuthVectorReq;
+        match AuthVectorReq::from_req(request.into_inner()) {
+            Ok(req) => av_request = req,
+            Err(e) => return Err(tonic::Status::new(tonic::Code::Aborted, e.to_string())),
+        }
+
+        match manager::find_vector(self.context.clone(), &av_request).await {
+            Ok(av_result) => {
+                tracing::info!("Returning result: {:?}", av_result);
+                Ok(tonic::Response::new(av_result.to_resp()))
+            }
+            Err(e) => {
+                tracing::error!("Error while handling request for {:?}: {}", av_request, e);
+                Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
+            }
+        }
+    }
+
+    /// Local request for to complete auth process for a vector.
+    /// No authentication is done.
+    async fn confirm_auth(
+        &self,
+        request: tonic::Request<AkaConfirmReq>,
+    ) -> Result<tonic::Response<AkaConfirmResp>, tonic::Status> {
+        tracing::info!("Request: {:?}", request);
+
+        let res_star = request.into_inner().res_star;
+        let res_star: auth_vector::types::ResStar =
+            res_star.try_into().or_else(|_e: Vec<u8>| {
+                Err(tonic::Status::new(
+                    tonic::Code::OutOfRange,
+                    "Unable to parse res_star",
+                ))
+            })?;
+
+        let kseaf = manager::confirm_auth_vector(self.context.clone(), res_star)
+            .await
+            .or_else(|e| Err(tonic::Status::new(tonic::Code::NotFound, e.to_string())))?;
+
+        let response_payload = AkaConfirmResp {
+            error: aka_confirm_resp::ErrorKind::NoError as i32,
+            kseaf: kseaf.to_vec(),
+        };
+
+        Ok(tonic::Response::new(response_payload))
+    }
+}

--- a/manager-rs/dauth-service/src/rpc/handlers/local_authentication.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/local_authentication.rs
@@ -1,12 +1,18 @@
+use std::sync::Arc;
+
+use crate::data::context::DauthContext;
 use crate::data::vector::AuthVectorReq;
 use crate::manager;
 use crate::rpc::dauth::local::aka_confirm_resp;
 use crate::rpc::dauth::local::local_authentication_server::LocalAuthentication;
 use crate::rpc::dauth::local::{AkaConfirmReq, AkaConfirmResp, AkaVectorReq, AkaVectorResp};
-use crate::rpc::handlers::handler::DauthHandler;
+
+pub struct LocalAuthenticationHandler {
+    pub context: Arc<DauthContext>,
+}
 
 #[tonic::async_trait]
-impl LocalAuthentication for DauthHandler {
+impl LocalAuthentication for LocalAuthenticationHandler {
     /// Local request for a vector that will be used on this network.
     /// No authentication is done.
     async fn get_auth_vector(

--- a/manager-rs/dauth-service/src/rpc/handlers/local_authentication.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/local_authentication.rs
@@ -1,9 +1,9 @@
 use crate::data::vector::AuthVectorReq;
 use crate::manager;
-use crate::rpc::handlers::handler::DauthHandler;
 use crate::rpc::dauth::local::aka_confirm_resp;
 use crate::rpc::dauth::local::local_authentication_server::LocalAuthentication;
 use crate::rpc::dauth::local::{AkaConfirmReq, AkaConfirmResp, AkaVectorReq, AkaVectorResp};
+use crate::rpc::handlers::handler::DauthHandler;
 
 #[tonic::async_trait]
 impl LocalAuthentication for DauthHandler {

--- a/manager-rs/dauth-service/src/rpc/handlers/mod.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/mod.rs
@@ -1,4 +1,3 @@
 pub mod backup_network;
-pub mod handler;
 pub mod home_network;
 pub mod local_authentication;

--- a/manager-rs/dauth-service/src/rpc/handlers/mod.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/mod.rs
@@ -1,4 +1,4 @@
 pub mod backup_network;
+pub mod handler;
 pub mod home_network;
 pub mod local_authentication;
-pub mod handler;

--- a/manager-rs/dauth-service/src/rpc/handlers/mod.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/mod.rs
@@ -1,0 +1,4 @@
+pub mod backup_network;
+pub mod home_network;
+pub mod local_authentication;
+pub mod handler;

--- a/manager-rs/dauth-service/src/rpc/mod.rs
+++ b/manager-rs/dauth-service/src/rpc/mod.rs
@@ -1,5 +1,5 @@
 pub mod clients;
-mod handler;
+pub mod handlers;
 pub mod server;
 
 pub mod dauth {

--- a/manager-rs/dauth-service/src/rpc/server.rs
+++ b/manager-rs/dauth-service/src/rpc/server.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tonic::transport::Server;
 
 use crate::data::context::DauthContext;
-use crate::rpc::handler::DauthHandler;
+use crate::rpc::handlers::handler::DauthHandler;
 
 use crate::rpc::dauth::local::local_authentication_server::LocalAuthenticationServer;
 use crate::rpc::dauth::remote::home_network_server::HomeNetworkServer;

--- a/manager-rs/dauth-service/src/rpc/server.rs
+++ b/manager-rs/dauth-service/src/rpc/server.rs
@@ -3,9 +3,12 @@ use std::sync::Arc;
 use tonic::transport::Server;
 
 use crate::data::context::DauthContext;
-use crate::rpc::handlers::handler::DauthHandler;
+use crate::rpc::handlers::backup_network::BackupNetworkHandler;
+use crate::rpc::handlers::home_network::HomeNetworkHandler;
+use crate::rpc::handlers::local_authentication::LocalAuthenticationHandler;
 
 use crate::rpc::dauth::local::local_authentication_server::LocalAuthenticationServer;
+use crate::rpc::dauth::remote::backup_network_server::BackupNetworkServer;
 use crate::rpc::dauth::remote::home_network_server::HomeNetworkServer;
 
 // TODO(matt9j) Probably should return a result in case server start fails
@@ -14,10 +17,13 @@ pub async fn start_server(context: Arc<DauthContext>) {
     tracing::info!("Hosting RPC server on {}", context.rpc_context.host_addr);
 
     Server::builder()
-        .add_service(LocalAuthenticationServer::new(DauthHandler {
+        .add_service(LocalAuthenticationServer::new(LocalAuthenticationHandler {
             context: context.clone(),
         }))
-        .add_service(HomeNetworkServer::new(DauthHandler {
+        .add_service(HomeNetworkServer::new(HomeNetworkHandler {
+            context: context.clone(),
+        }))
+        .add_service(BackupNetworkServer::new(BackupNetworkHandler {
             context: context.clone(),
         }))
         .serve(context.rpc_context.host_addr.parse().unwrap())


### PR DESCRIPTION
Simple refactor of handlers and clients, should make it easier to read/manage. Also includes outlines of all client calls so we can reference them for later dev work.