### PR TITLE
Vector state and sqn slice

### DIFF
--- a/manager-rs/configs/dauth-service/sample1.yaml
+++ b/manager-rs/configs/dauth-service/sample1.yaml
@@ -14,10 +14,13 @@ ed25519_keyfile_path: "./out/sample-network-1/dauth_service/ed25519_keys"
 database_path: "./out/sample-network-1/dauth_service/sqlite1.db"
 
 # Delay in seconds before tasks thread begins executing
-task_startup_delay: 5.0
+task_startup_delay: 1.0
 
 # Interval in seconds between checking for new tasks
-task_interval: 10.0
+task_interval: 1.0
+
+# Max number of auth vectors a backup network should have at one time
+max_backup_vectors: 10
 
 # The set of users for this network (for testing)
 users: {

--- a/manager-rs/configs/dauth-service/sample1.yaml
+++ b/manager-rs/configs/dauth-service/sample1.yaml
@@ -24,7 +24,7 @@ users: {
   "imsi-901700000000001": {
     "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
     "opc": "E8ED289DEBA952E4283B54E88E6183CA",
-    "sqn_max": "32",
+    "sqn_max": "33",
     "sqn_slice": 1,
     "backup_network_ids": [
       "sample-network-2"

--- a/manager-rs/configs/dauth-service/sample1.yaml
+++ b/manager-rs/configs/dauth-service/sample1.yaml
@@ -25,6 +25,7 @@ users: {
     "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
     "opc": "E8ED289DEBA952E4283B54E88E6183CA",
     "sqn_max": "32",
+    "sqn_slice": 1,
     "backup_network_ids": [
       "sample-network-2"
     ]

--- a/manager-rs/configs/dauth-service/sample1.yaml
+++ b/manager-rs/configs/dauth-service/sample1.yaml
@@ -31,10 +31,16 @@ users: {
   "imsi-901700000000001": {
     "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
     "opc": "E8ED289DEBA952E4283B54E88E6183CA",
-    "sqn_max": "33",
-    "sqn_slice": 1,
-    "backup_network_ids": [
-      "sample-network-2"
-    ]
+
+    # Mapping of sqn slice to max sqn for that slice
+    "sqn_slice_max": {
+      0: 32,
+      1: 33
+    },
+
+    # Mapping of network id to sqn slice
+    "backup_network_ids": {
+      "sample-network-2": 1
+    }
   }
 }

--- a/manager-rs/configs/dauth-service/sample1.yaml
+++ b/manager-rs/configs/dauth-service/sample1.yaml
@@ -19,6 +19,10 @@ task_startup_delay: 1.0
 # Interval in seconds between checking for new tasks
 task_interval: 1.0
 
+# The number of vector slices possible (also determines max backup networks)
+# Slice 0 is always reserved for the home network
+num_sqn_slices: 32
+
 # Max number of auth vectors a backup network should have at one time
 max_backup_vectors: 10
 

--- a/manager-rs/configs/dauth-service/sample2.yaml
+++ b/manager-rs/configs/dauth-service/sample2.yaml
@@ -24,7 +24,7 @@ users: {
   "imsi-901700000000002": {
     "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
     "opc": "E8ED289DEBA952E4283B54E88E6183CA",
-    "sqn_max": "32",
+    "sqn_max": "33",
     "sqn_slice": 1,
     "backup_network_ids": [
       "sample-network-1"

--- a/manager-rs/configs/dauth-service/sample2.yaml
+++ b/manager-rs/configs/dauth-service/sample2.yaml
@@ -31,10 +31,16 @@ users: {
   "imsi-901700000000002": {
     "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
     "opc": "E8ED289DEBA952E4283B54E88E6183CA",
-    "sqn_max": "33",
-    "sqn_slice": 1,
-    "backup_network_ids": [
-      "sample-network-1"
-    ]
+
+    # Mapping of sqn slice to max sqn for that slice
+    "sqn_slice_max": {
+      0: 32,
+      1: 33
+    },
+
+    # Mapping of network id to sqn slice
+    "backup_network_ids": {
+      "sample-network-1": 1
+    }
   }
 }

--- a/manager-rs/configs/dauth-service/sample2.yaml
+++ b/manager-rs/configs/dauth-service/sample2.yaml
@@ -14,10 +14,13 @@ ed25519_keyfile_path: "./out/sample-network-2/dauth_service/ed25519_keys"
 database_path: "./out/sample-network-2/dauth_service/sqlite1.db"
 
 # Delay in seconds before tasks thread begins executing
-task_startup_delay: 5.0
+task_startup_delay: 1.0
 
 # Interval in seconds between checking for new tasks
-task_interval: 10.0
+task_interval: 1.0
+
+# Max number of auth vectors a backup network should have at one time
+max_backup_vectors: 10
 
 # The set of users for this network (for testing)
 users: {

--- a/manager-rs/configs/dauth-service/sample2.yaml
+++ b/manager-rs/configs/dauth-service/sample2.yaml
@@ -25,6 +25,7 @@ users: {
     "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
     "opc": "E8ED289DEBA952E4283B54E88E6183CA",
     "sqn_max": "32",
+    "sqn_slice": 1,
     "backup_network_ids": [
       "sample-network-1"
     ]

--- a/manager-rs/configs/dauth-service/sample2.yaml
+++ b/manager-rs/configs/dauth-service/sample2.yaml
@@ -19,6 +19,10 @@ task_startup_delay: 1.0
 # Interval in seconds between checking for new tasks
 task_interval: 1.0
 
+# The number of vector slices possible (also determines max backup networks)
+# Slice 0 is always reserved for the home network
+num_sqn_slices: 32
+
 # Max number of auth vectors a backup network should have at one time
 max_backup_vectors: 10
 

--- a/manager-rs/dauth-service/src/data/config.rs
+++ b/manager-rs/dauth-service/src/data/config.rs
@@ -31,8 +31,7 @@ pub struct UserInfoConfig {
     pub k: String,
     pub opc: String,
     pub sqn_max: String,
-    pub sqn_slice: u32,
-    pub backup_network_ids: Vec<String>,
+    pub backup_network_ids: HashMap<String, u32>,
 }
 
 impl UserInfoConfig {
@@ -46,11 +45,6 @@ impl UserInfoConfig {
         let sqn_max: Sqn =
             utilities::convert_int_string_to_byte_vec_with_length(&self.sqn_max, SQN_LENGTH)?[..]
                 .try_into()?;
-        Ok(UserInfo {
-            k,
-            opc,
-            sqn_max,
-            sqn_slice: self.sqn_slice,
-        })
+        Ok(UserInfo { k, opc, sqn_max })
     }
 }

--- a/manager-rs/dauth-service/src/data/config.rs
+++ b/manager-rs/dauth-service/src/data/config.rs
@@ -48,7 +48,7 @@ impl UserInfoConfig {
             k,
             opc,
             sqn_max,
-            sqn_slice: self.sqn_slice,
+            sqn_slice: self.sqn_slice % 32,
         })
     }
 }

--- a/manager-rs/dauth-service/src/data/config.rs
+++ b/manager-rs/dauth-service/src/data/config.rs
@@ -18,6 +18,7 @@ pub struct DauthConfig {
     pub directory_addr: String,
     pub ed25519_keyfile_path: String,
     pub database_path: String,
+    pub max_backup_vectors: u32,
     pub task_startup_delay: f64,
     pub task_interval: f64,
 }

--- a/manager-rs/dauth-service/src/data/config.rs
+++ b/manager-rs/dauth-service/src/data/config.rs
@@ -30,21 +30,23 @@ pub struct DauthConfig {
 pub struct UserInfoConfig {
     pub k: String,
     pub opc: String,
-    pub sqn_max: String,
+    pub sqn_slice_max: HashMap<u32, u64>,
     pub backup_network_ids: HashMap<String, u32>,
 }
 
 impl UserInfoConfig {
     /// Generates a user info object with byte arrays
-    pub fn to_user_info(&self) -> Result<UserInfo, DauthError> {
-        let k: K = utilities::convert_hex_string_to_byte_vec_with_length(&self.k, K_LENGTH)?[..]
-            .try_into()?;
-        let opc: Opc =
+    pub fn get_k(&self) -> Result<K, DauthError> {
+        Ok(
+            utilities::convert_hex_string_to_byte_vec_with_length(&self.k, K_LENGTH)?[..]
+                .try_into()?,
+        )
+    }
+    /// Generates a user info object with byte arrays
+    pub fn get_opc(&self) -> Result<Opc, DauthError> {
+        Ok(
             utilities::convert_hex_string_to_byte_vec_with_length(&self.opc, OPC_LENGTH)?[..]
-                .try_into()?;
-        let sqn_max: Sqn =
-            utilities::convert_int_string_to_byte_vec_with_length(&self.sqn_max, SQN_LENGTH)?[..]
-                .try_into()?;
-        Ok(UserInfo { k, opc, sqn_max })
+                .try_into()?,
+        )
     }
 }

--- a/manager-rs/dauth-service/src/data/config.rs
+++ b/manager-rs/dauth-service/src/data/config.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use auth_vector::{
-    constants::{K_LENGTH, OPC_LENGTH, SQN_LENGTH},
-    types::{Opc, Sqn, K},
+    constants::{K_LENGTH, OPC_LENGTH},
+    types::{Opc, K},
 };
 
-use crate::data::{error::DauthError, user_info::UserInfo, utilities};
+use crate::data::{error::DauthError, utilities};
 
 /// Holds all configuration data from a corresponding YAML file
 #[derive(Serialize, Deserialize, Debug)]
@@ -18,8 +18,8 @@ pub struct DauthConfig {
     pub directory_addr: String,
     pub ed25519_keyfile_path: String,
     pub database_path: String,
-    pub num_sqn_slices: u32,
-    pub max_backup_vectors: u32,
+    pub num_sqn_slices: i64,
+    pub max_backup_vectors: i64,
     pub task_startup_delay: f64,
     pub task_interval: f64,
 }
@@ -30,8 +30,8 @@ pub struct DauthConfig {
 pub struct UserInfoConfig {
     pub k: String,
     pub opc: String,
-    pub sqn_slice_max: HashMap<u32, u64>,
-    pub backup_network_ids: HashMap<String, u32>,
+    pub sqn_slice_max: HashMap<i64, i64>,
+    pub backup_network_ids: HashMap<String, i64>,
 }
 
 impl UserInfoConfig {

--- a/manager-rs/dauth-service/src/data/config.rs
+++ b/manager-rs/dauth-service/src/data/config.rs
@@ -18,6 +18,7 @@ pub struct DauthConfig {
     pub directory_addr: String,
     pub ed25519_keyfile_path: String,
     pub database_path: String,
+    pub num_sqn_slices: u32,
     pub max_backup_vectors: u32,
     pub task_startup_delay: f64,
     pub task_interval: f64,
@@ -49,7 +50,7 @@ impl UserInfoConfig {
             k,
             opc,
             sqn_max,
-            sqn_slice: self.sqn_slice % 32,
+            sqn_slice: self.sqn_slice,
         })
     }
 }

--- a/manager-rs/dauth-service/src/data/config.rs
+++ b/manager-rs/dauth-service/src/data/config.rs
@@ -29,6 +29,7 @@ pub struct UserInfoConfig {
     pub k: String,
     pub opc: String,
     pub sqn_max: String,
+    pub sqn_slice: u32,
     pub backup_network_ids: Vec<String>,
 }
 
@@ -43,6 +44,11 @@ impl UserInfoConfig {
         let sqn_max: Sqn =
             utilities::convert_int_string_to_byte_vec_with_length(&self.sqn_max, SQN_LENGTH)?[..]
                 .try_into()?;
-        Ok(UserInfo { k, opc, sqn_max })
+        Ok(UserInfo {
+            k,
+            opc,
+            sqn_max,
+            sqn_slice: self.sqn_slice,
+        })
     }
 }

--- a/manager-rs/dauth-service/src/data/context.rs
+++ b/manager-rs/dauth-service/src/data/context.rs
@@ -23,6 +23,7 @@ pub struct LocalContext {
     pub id: String,
     pub database_pool: SqlitePool,
     pub signing_keys: Keypair,
+    pub num_sqn_slices: u32,
     pub max_backup_vectors: u32,
 }
 

--- a/manager-rs/dauth-service/src/data/context.rs
+++ b/manager-rs/dauth-service/src/data/context.rs
@@ -23,6 +23,7 @@ pub struct LocalContext {
     pub id: String,
     pub database_pool: SqlitePool,
     pub signing_keys: Keypair,
+    pub max_backup_vectors: u32,
 }
 
 #[derive(Debug)]

--- a/manager-rs/dauth-service/src/data/context.rs
+++ b/manager-rs/dauth-service/src/data/context.rs
@@ -23,8 +23,8 @@ pub struct LocalContext {
     pub id: String,
     pub database_pool: SqlitePool,
     pub signing_keys: Keypair,
-    pub num_sqn_slices: u32,
-    pub max_backup_vectors: u32,
+    pub num_sqn_slices: i64,
+    pub max_backup_vectors: i64,
 }
 
 #[derive(Debug)]

--- a/manager-rs/dauth-service/src/data/user_info.rs
+++ b/manager-rs/dauth-service/src/data/user_info.rs
@@ -1,96 +1,9 @@
-use auth_vector::types::{Opc, Sqn, K};
+use auth_vector::types::{Opc, K};
 
 /// Holds sensitive user info needed for auth vector generation
 #[derive(Debug)]
 pub struct UserInfo {
     pub k: K,
     pub opc: Opc,
-    pub sqn_max: Sqn,
-}
-
-impl UserInfo {
-    pub fn increment_sqn(&mut self, mut amount: u64) {
-        let mut i = self.sqn_max.len() - 1;
-
-        while amount > 0 {
-            amount += self.sqn_max[i] as u64;
-            self.sqn_max[i] = amount as u8;
-            amount /= 256;
-
-            if i == 0 {
-                break;
-            }
-            i -= 1;
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::data::user_info::UserInfo;
-
-    #[test]
-    fn test_increment() {
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            0
-        ));
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 1],
-            1
-        ));
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 2],
-            2
-        ));
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 255],
-            255
-        ));
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 1, 0],
-            256
-        ));
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 1, 0, 0],
-            256 * 256
-        ));
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 1, 0],
-            [0, 0, 0, 0, 1, 1],
-            1
-        ));
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 1, 0],
-            [0, 0, 0, 0, 2, 0],
-            256
-        ));
-        assert!(check_increment_result(
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            256 * 256 * 256 * 256 * 256 * 256
-        ));
-    }
-
-    fn check_increment_result(
-        v1: auth_vector::types::Sqn,
-        v2: auth_vector::types::Sqn,
-        amount: u64,
-    ) -> bool {
-        let mut ui = UserInfo {
-            k: [0; auth_vector::constants::K_LENGTH],
-            opc: [0; auth_vector::constants::OPC_LENGTH],
-            sqn_max: v1,
-        };
-
-        ui.increment_sqn(amount);
-
-        ui.sqn_max == v2
-    }
+    pub sqn: u64,
 }

--- a/manager-rs/dauth-service/src/data/user_info.rs
+++ b/manager-rs/dauth-service/src/data/user_info.rs
@@ -6,6 +6,7 @@ pub struct UserInfo {
     pub k: K,
     pub opc: Opc,
     pub sqn_max: Sqn,
+    pub sqn_slice: u32,
 }
 
 impl UserInfo {
@@ -87,6 +88,7 @@ mod tests {
             k: [0; auth_vector::constants::K_LENGTH],
             opc: [0; auth_vector::constants::OPC_LENGTH],
             sqn_max: v1,
+            sqn_slice: 0,
         };
 
         ui.increment_sqn(amount);

--- a/manager-rs/dauth-service/src/data/user_info.rs
+++ b/manager-rs/dauth-service/src/data/user_info.rs
@@ -6,7 +6,6 @@ pub struct UserInfo {
     pub k: K,
     pub opc: Opc,
     pub sqn_max: Sqn,
-    pub sqn_slice: u32,
 }
 
 impl UserInfo {
@@ -88,7 +87,6 @@ mod tests {
             k: [0; auth_vector::constants::K_LENGTH],
             opc: [0; auth_vector::constants::OPC_LENGTH],
             sqn_max: v1,
-            sqn_slice: 0,
         };
 
         ui.increment_sqn(amount);

--- a/manager-rs/dauth-service/src/data/user_info.rs
+++ b/manager-rs/dauth-service/src/data/user_info.rs
@@ -5,5 +5,5 @@ use auth_vector::types::{Opc, K};
 pub struct UserInfo {
     pub k: K,
     pub opc: Opc,
-    pub sqn: u64,
+    pub sqn: i64,
 }

--- a/manager-rs/dauth-service/src/database/backup_networks.rs
+++ b/manager-rs/dauth-service/src/database/backup_networks.rs
@@ -1,5 +1,5 @@
 use sqlx::sqlite::{SqlitePool, SqliteRow};
-use sqlx::Error as SqlxError;
+use sqlx::{Error as SqlxError, Row};
 use sqlx::{Sqlite, Transaction};
 
 use crate::data::error::DauthError;
@@ -56,6 +56,23 @@ pub async fn get(
     .bind(backup_network_id)
     .fetch_one(transaction)
     .await?)
+}
+
+/// Gets the backup info for a given network and user id
+pub async fn get_slice(
+    transaction: &mut Transaction<'_, Sqlite>,
+    user_id: &str,
+    backup_network_id: &str,
+) -> Result<u32, SqlxError> {
+    Ok(sqlx::query(
+        "SELECT seq_num_slice FROM backup_networks_table
+        WHERE (user_id,backup_network_id)=($1,$2);",
+    )
+    .bind(user_id)
+    .bind(backup_network_id)
+    .fetch_one(transaction)
+    .await?
+    .try_get::<u32, &str>("seq_num_slice")?)
 }
 
 /// Removes the network as a backup for this network

--- a/manager-rs/dauth-service/src/database/backup_networks.rs
+++ b/manager-rs/dauth-service/src/database/backup_networks.rs
@@ -22,15 +22,16 @@ pub async fn init_table(pool: &SqlitePool) -> Result<(), DauthError> {
 
 /* Queries */
 
-/// Adds a network as a backup for the user id and seqnum slice
-pub async fn add(
+/// Adds a network as a backup for the user id and seqnum slice.
+/// Changes seqnum slice if user/network pair exists.
+pub async fn upsert(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
     backup_network_id: &str,
     seqnum_slice: u32,
 ) -> Result<(), SqlxError> {
     sqlx::query(
-        "INSERT INTO backup_networks_table
+        "REPLACE INTO backup_networks_table
         VALUES ($1,$2,$3)",
     )
     .bind(user_id)
@@ -128,7 +129,7 @@ mod tests {
 
     /// Test that insert works
     #[tokio::test]
-    async fn test_add() {
+    async fn test_upsert() {
         let (pool, _dir) = init().await;
 
         let mut transaction = pool.begin().await.unwrap();
@@ -138,7 +139,7 @@ mod tests {
 
         for section in 0..num_sections {
             for row in 0..num_rows {
-                backup_networks::add(
+                backup_networks::upsert(
                     &mut transaction,
                     &format!("test_user_id_{}", row),
                     &format!("test_network_id_{}", section),
@@ -163,7 +164,7 @@ mod tests {
 
         for section in 0..num_sections {
             for row in 0..num_rows {
-                backup_networks::add(
+                backup_networks::upsert(
                     &mut transaction,
                     &format!("test_user_id_{}", row),
                     &format!("test_network_id_{}", section),
@@ -205,7 +206,7 @@ mod tests {
 
         for section in 0..num_sections {
             for row in 0..num_rows {
-                backup_networks::add(
+                backup_networks::upsert(
                     &mut transaction,
                     &format!("test_user_id_{}", row),
                     &format!("test_network_id_{}", section),

--- a/manager-rs/dauth-service/src/database/backup_networks.rs
+++ b/manager-rs/dauth-service/src/database/backup_networks.rs
@@ -28,7 +28,7 @@ pub async fn upsert(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
     backup_network_id: &str,
-    seqnum_slice: u32,
+    seqnum_slice: i64,
 ) -> Result<(), SqlxError> {
     sqlx::query(
         "REPLACE INTO backup_networks_table
@@ -64,7 +64,7 @@ pub async fn get_slice(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
     backup_network_id: &str,
-) -> Result<u32, SqlxError> {
+) -> Result<i64, SqlxError> {
     Ok(sqlx::query(
         "SELECT seq_num_slice FROM backup_networks_table
         WHERE (user_id,backup_network_id)=($1,$2);",
@@ -73,7 +73,7 @@ pub async fn get_slice(
     .bind(backup_network_id)
     .fetch_one(transaction)
     .await?
-    .try_get::<u32, &str>("seq_num_slice")?)
+    .try_get::<i64, &str>("seq_num_slice")?)
 }
 
 /// Removes the network as a backup for this network
@@ -188,7 +188,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                assert_eq!(section, res.get_unchecked::<u32, &str>("seq_num_slice"));
+                assert_eq!(section, res.get_unchecked::<i64, &str>("seq_num_slice"));
             }
         }
         transaction.commit().await.unwrap();

--- a/manager-rs/dauth-service/src/database/backup_networks.rs
+++ b/manager-rs/dauth-service/src/database/backup_networks.rs
@@ -27,7 +27,7 @@ pub async fn add(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
     backup_network_id: &str,
-    seqnum_slice: i32,
+    seqnum_slice: u32,
 ) -> Result<(), SqlxError> {
     sqlx::query(
         "INSERT INTO backup_networks_table
@@ -187,7 +187,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                assert_eq!(section, res.get_unchecked::<i32, &str>("seq_num_slice"));
+                assert_eq!(section, res.get_unchecked::<u32, &str>("seq_num_slice"));
             }
         }
         transaction.commit().await.unwrap();

--- a/manager-rs/dauth-service/src/database/backup_users.rs
+++ b/manager-rs/dauth-service/src/database/backup_users.rs
@@ -28,7 +28,7 @@ pub async fn add(
     home_network_id: &str,
 ) -> Result<(), SqlxError> {
     sqlx::query(
-        "INSERT INTO backup_users_table
+        "REPLACE INTO backup_users_table
         VALUES ($1,$2)",
     )
     .bind(user_id)

--- a/manager-rs/dauth-service/src/database/general.rs
+++ b/manager-rs/dauth-service/src/database/general.rs
@@ -21,7 +21,7 @@ pub async fn database_init(database_path: &str) -> Result<SqlitePool, DauthError
     let path = std::path::Path::new(database_path);
     let prefix = path.parent().unwrap();
     std::fs::create_dir_all(prefix).unwrap();
-    
+
     let pool: SqlitePool = database::general::build_pool(database_path).await?;
 
     database::flood_vectors::init_table(&pool).await?;
@@ -31,6 +31,7 @@ pub async fn database_init(database_path: &str) -> Result<SqlitePool, DauthError
     database::key_shares::init_table(&pool).await?;
     database::backup_networks::init_table(&pool).await?;
     database::backup_users::init_table(&pool).await?;
+    database::vector_state::init_table(&pool).await?;
     database::tasks::update_users::init_table(&pool).await?;
 
     Ok(pool)

--- a/manager-rs/dauth-service/src/database/mod.rs
+++ b/manager-rs/dauth-service/src/database/mod.rs
@@ -8,3 +8,4 @@ pub mod kseafs;
 pub mod tasks;
 pub mod user_infos;
 pub mod utilities;
+pub mod vector_state;

--- a/manager-rs/dauth-service/src/database/tasks/update_users.rs
+++ b/manager-rs/dauth-service/src/database/tasks/update_users.rs
@@ -138,16 +138,18 @@ mod tests {
 
         let mut transaction = pool.begin().await.unwrap();
         for row in 0..num_rows {
-            user_infos::upsert(
-                &mut transaction,
-                &format!("test_user_id_{}", row),
-                &[0u8, 3],
-                &[0u8, 3],
-                &[0u8, 3],
-                0,
-            )
-            .await
-            .unwrap();
+            for sqn_max in 0..3 {
+                user_infos::upsert(
+                    &mut transaction,
+                    &format!("test_user_id_{}", row),
+                    &[0u8, 3],
+                    &[0u8, 3],
+                    sqn_max,
+                    sqn_max as u32,
+                )
+                .await
+                .unwrap();
+            }
 
             tasks::update_users::add(
                 &mut transaction,
@@ -189,16 +191,18 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut transaction = pool.begin().await.unwrap();
-        user_infos::upsert(
-            &mut transaction,
-            &"test_user_id".to_string(),
-            &[0u8, 3],
-            &[0u8, 3],
-            &[0u8, 3],
-            0,
-        )
-        .await
-        .unwrap();
+        for sqn_max in 0..3 {
+            user_infos::upsert(
+                &mut transaction,
+                &"test_user_id".to_string(),
+                &[0u8, 3],
+                &[0u8, 3],
+                sqn_max,
+                sqn_max as u32,
+            )
+            .await
+            .unwrap();
+        }
 
         tasks::update_users::add(&mut transaction, "test_user_id", 0, "test_network_id_a")
             .await
@@ -231,16 +235,18 @@ mod tests {
 
         let mut transaction = pool.begin().await.unwrap();
         for row in 0..num_rows {
-            user_infos::upsert(
-                &mut transaction,
-                &format!("test_user_id_{}", row),
-                &[0u8, 3],
-                &[0u8, 3],
-                &[0u8, 3],
-                0,
-            )
-            .await
-            .unwrap();
+            for sqn_max in 0..3 {
+                user_infos::upsert(
+                    &mut transaction,
+                    &format!("test_user_id_{}", row),
+                    &[0u8, 3],
+                    &[0u8, 3],
+                    sqn_max,
+                    sqn_max as u32,
+                )
+                .await
+                .unwrap();
+            }
 
             tasks::update_users::add(
                 &mut transaction,

--- a/manager-rs/dauth-service/src/database/tasks/update_users.rs
+++ b/manager-rs/dauth-service/src/database/tasks/update_users.rs
@@ -13,7 +13,7 @@ pub async fn init_table(pool: &SqlitePool) -> Result<(), DauthError> {
             backup_network_id INT NOT NULL,
             PRIMARY KEY (user_id, sqn_slice),
             FOREIGN KEY (user_id, sqn_slice) 
-                REFERENCES user_info_table(user_info_id, user_info_sqn_slice)
+                REFERENCES user_info_table(id, sqn_slice)
         );",
     )
     .execute(pool)
@@ -27,7 +27,7 @@ pub async fn init_table(pool: &SqlitePool) -> Result<(), DauthError> {
 pub async fn add(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
-    sqn_slice: u32,
+    sqn_slice: i64,
     backup_network_id: &str,
 ) -> Result<(), DauthError> {
     sqlx::query(
@@ -62,7 +62,7 @@ pub async fn get_user_ids(
 pub async fn get_user_data(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
-) -> Result<Vec<(String, u32)>, DauthError> {
+) -> Result<Vec<(String, i64)>, DauthError> {
     let mut result = Vec::new();
     let rows = sqlx::query(
         "SELECT * FROM task_update_users_table
@@ -75,7 +75,7 @@ pub async fn get_user_data(
     for row in rows {
         result.push((
             row.try_get::<String, &str>("backup_network_id")?,
-            row.try_get::<u32, &str>("sqn_slice")?,
+            row.try_get::<i64, &str>("sqn_slice")?,
         ));
     }
     Ok(result)
@@ -145,7 +145,7 @@ mod tests {
                     &[0u8, 3],
                     &[0u8, 3],
                     sqn_max,
-                    sqn_max as u32,
+                    sqn_max,
                 )
                 .await
                 .unwrap();
@@ -198,7 +198,7 @@ mod tests {
                 &[0u8, 3],
                 &[0u8, 3],
                 sqn_max,
-                sqn_max as u32,
+                sqn_max,
             )
             .await
             .unwrap();
@@ -242,7 +242,7 @@ mod tests {
                     &[0u8, 3],
                     &[0u8, 3],
                     sqn_max,
-                    sqn_max as u32,
+                    sqn_max,
                 )
                 .await
                 .unwrap();

--- a/manager-rs/dauth-service/src/database/tasks/update_users.rs
+++ b/manager-rs/dauth-service/src/database/tasks/update_users.rs
@@ -28,20 +28,17 @@ pub async fn add(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
     sqn_slice: u32,
-    backup_network_ids: &Vec<String>,
+    backup_network_id: &str,
 ) -> Result<(), DauthError> {
-    // TODO: Add more efficient multi insert?
-    for backup_network_id in backup_network_ids {
-        sqlx::query(
-            "REPLACE INTO task_update_users_table
-            VALUES ($1,$2,$3)",
-        )
-        .bind(user_id)
-        .bind(sqn_slice)
-        .bind(backup_network_id)
-        .execute(&mut *transaction)
-        .await?;
-    }
+    sqlx::query(
+        "REPLACE INTO task_update_users_table
+        VALUES ($1,$2,$3)",
+    )
+    .bind(user_id)
+    .bind(sqn_slice)
+    .bind(backup_network_id)
+    .execute(&mut *transaction)
+    .await?;
 
     Ok(())
 }
@@ -156,11 +153,23 @@ mod tests {
                 &mut transaction,
                 &format!("test_user_id_{}", row),
                 0,
-                &vec![
-                    "test_network_id_a".to_string(),
-                    "test_network_id_b".to_string(),
-                    "test_network_id_c".to_string(),
-                ],
+                "test_network_id_a",
+            )
+            .await
+            .unwrap();
+            tasks::update_users::add(
+                &mut transaction,
+                &format!("test_user_id_{}", row),
+                1,
+                "test_network_id_b",
+            )
+            .await
+            .unwrap();
+            tasks::update_users::add(
+                &mut transaction,
+                &format!("test_user_id_{}", row),
+                2,
+                "test_network_id_c",
             )
             .await
             .unwrap();
@@ -191,18 +200,15 @@ mod tests {
         .await
         .unwrap();
 
-        tasks::update_users::add(
-            &mut transaction,
-            "test_user_id",
-            0,
-            &vec![
-                "test_network_id_a".to_string(),
-                "test_network_id_b".to_string(),
-                "test_network_id_c".to_string(),
-            ],
-        )
-        .await
-        .unwrap();
+        tasks::update_users::add(&mut transaction, "test_user_id", 0, "test_network_id_a")
+            .await
+            .unwrap();
+        tasks::update_users::add(&mut transaction, "test_user_id", 1, "test_network_id_b")
+            .await
+            .unwrap();
+        tasks::update_users::add(&mut transaction, "test_user_id", 2, "test_network_id_c")
+            .await
+            .unwrap();
         transaction.commit().await.unwrap();
 
         let mut transaction = pool.begin().await.unwrap();
@@ -240,11 +246,23 @@ mod tests {
                 &mut transaction,
                 &format!("test_user_id_{}", row),
                 0,
-                &vec![
-                    "test_network_id_a".to_string(),
-                    "test_network_id_b".to_string(),
-                    "test_network_id_c".to_string(),
-                ],
+                "test_network_id_a",
+            )
+            .await
+            .unwrap();
+            tasks::update_users::add(
+                &mut transaction,
+                &format!("test_user_id_{}", row),
+                1,
+                "test_network_id_b",
+            )
+            .await
+            .unwrap();
+            tasks::update_users::add(
+                &mut transaction,
+                &format!("test_user_id_{}", row),
+                2,
+                "test_network_id_c",
             )
             .await
             .unwrap();

--- a/manager-rs/dauth-service/src/database/tasks/update_users.rs
+++ b/manager-rs/dauth-service/src/database/tasks/update_users.rs
@@ -62,7 +62,7 @@ pub async fn get_user_ids(
 }
 
 /// Gets all backup network ids and sqn slices for a given user id.
-pub async fn get_backup_network_ids(
+pub async fn get_user_data(
     transaction: &mut Transaction<'_, Sqlite>,
     user_id: &str,
 ) -> Result<Vec<(String, u32)>, DauthError> {
@@ -213,7 +213,7 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut transaction = pool.begin().await.unwrap();
-        tasks::update_users::get_backup_network_ids(&mut transaction, user_id)
+        tasks::update_users::get_user_data(&mut transaction, user_id)
             .await
             .unwrap();
     }

--- a/manager-rs/dauth-service/src/database/utilities.rs
+++ b/manager-rs/dauth-service/src/database/utilities.rs
@@ -41,7 +41,6 @@ impl DauthDataUtilities for SqliteRow {
             sqn_max: self
                 .try_get::<&[u8], &str>("user_info_sqn_max")?
                 .try_into()?,
-            sqn_slice: self.try_get::<u32, &str>("user_info_sqn_slice")?,
         })
     }
 

--- a/manager-rs/dauth-service/src/database/utilities.rs
+++ b/manager-rs/dauth-service/src/database/utilities.rs
@@ -36,9 +36,9 @@ impl DauthDataUtilities for SqliteRow {
 
     fn to_user_info(&self) -> Result<UserInfo, DauthError> {
         Ok(UserInfo {
-            k: self.try_get::<&[u8], &str>("user_info_k")?.try_into()?,
-            opc: self.try_get::<&[u8], &str>("user_info_opc")?.try_into()?,
-            sqn: self.try_get::<i64, &str>("user_info_sqn_max")? as u64,
+            k: self.try_get::<&[u8], &str>("k")?.try_into()?,
+            opc: self.try_get::<&[u8], &str>("opc")?.try_into()?,
+            sqn: self.try_get::<i64, &str>("sqn_max")?,
         })
     }
 

--- a/manager-rs/dauth-service/src/database/utilities.rs
+++ b/manager-rs/dauth-service/src/database/utilities.rs
@@ -41,6 +41,7 @@ impl DauthDataUtilities for SqliteRow {
             sqn_max: self
                 .try_get::<&[u8], &str>("user_info_sqn_max")?
                 .try_into()?,
+            sqn_slice: self.try_get::<u32, &str>("user_info_sqn_slice")?,
         })
     }
 

--- a/manager-rs/dauth-service/src/database/utilities.rs
+++ b/manager-rs/dauth-service/src/database/utilities.rs
@@ -38,9 +38,7 @@ impl DauthDataUtilities for SqliteRow {
         Ok(UserInfo {
             k: self.try_get::<&[u8], &str>("user_info_k")?.try_into()?,
             opc: self.try_get::<&[u8], &str>("user_info_opc")?.try_into()?,
-            sqn_max: self
-                .try_get::<&[u8], &str>("user_info_sqn_max")?
-                .try_into()?,
+            sqn: self.try_get::<i64, &str>("user_info_sqn_max")? as u64,
         })
     }
 

--- a/manager-rs/dauth-service/src/database/vector_state.rs
+++ b/manager-rs/dauth-service/src/database/vector_state.rs
@@ -1,4 +1,3 @@
-use auth_vector::types::HresStar;
 use sqlx::sqlite::SqlitePool;
 use sqlx::{Row, Sqlite, Transaction};
 
@@ -71,9 +70,9 @@ pub async fn get_all_by_id(
     .fetch_all(transaction)
     .await?;
 
-    let mut hashes = Vec::new();
+    let mut hashes = Vec::with_capacity(res.len());
     for row in res {
-        hashes.push(row.try_get::<Vec<u8>, &str>("backup_network_id")?)
+        hashes.push(row.try_get::<Vec<u8>, &str>("xres_star_hash")?)
     }
     Ok(hashes)
 }

--- a/manager-rs/dauth-service/src/database/vector_state.rs
+++ b/manager-rs/dauth-service/src/database/vector_state.rs
@@ -1,0 +1,195 @@
+use sqlx::sqlite::SqlitePool;
+use sqlx::{Row, Sqlite, Transaction};
+
+use crate::data::error::DauthError;
+
+/// Creates the vector state table if it does not exist already.
+pub async fn init_table(pool: &SqlitePool) -> Result<(), DauthError> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS vector_state_table (
+            xres_star_hash BLOB PRIMARY KEY,
+            backup_network_id TEXT NOT NULL
+        );",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/* Queries */
+
+/// Adds the auth vector as owned by the backup network.
+/// Use xres* hash as the reference for the auth vector.
+pub async fn add(
+    transaction: &mut Transaction<'_, Sqlite>,
+    xres_star_hash: &[u8],
+    backup_network_id: &str,
+) -> Result<(), DauthError> {
+    sqlx::query(
+        "INSERT INTO vector_state_table
+        VALUES ($1,$2)",
+    )
+    .bind(xres_star_hash)
+    .bind(backup_network_id)
+    .execute(transaction)
+    .await?;
+
+    Ok(())
+}
+
+/// Returns the owning network of the auth vector.
+pub async fn get(
+    transaction: &mut Transaction<'_, Sqlite>,
+    xres_star_hash: &[u8],
+) -> Result<String, DauthError> {
+    Ok(sqlx::query(
+        "SELECT * FROM vector_state_table
+        WHERE xres_star_hash=$1;",
+    )
+    .bind(xres_star_hash)
+    .fetch_one(transaction)
+    .await?
+    .try_get::<String, &str>("backup_network_id")?)
+}
+
+/// Deletes a vector reference if found.
+pub async fn remove(
+    transaction: &mut Transaction<'_, Sqlite>,
+    xres_star_hash: &[u8],
+) -> Result<(), DauthError> {
+    sqlx::query(
+        "DELETE FROM vector_state_table
+        WHERE xres_star_hash=$1",
+    )
+    .bind(xres_star_hash)
+    .execute(transaction)
+    .await?;
+
+    Ok(())
+}
+
+/* Testing */
+
+#[cfg(test)]
+mod tests {
+    use rand::distributions::Alphanumeric;
+    use rand::{thread_rng, Rng};
+    use sqlx::SqlitePool;
+    use tempfile::{tempdir, TempDir};
+
+    use crate::database::{general, vector_state};
+
+    fn gen_name() -> String {
+        let s: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
+
+        format!("sqlite_{}.db", s)
+    }
+
+    async fn init() -> (SqlitePool, TempDir) {
+        let dir = tempdir().unwrap();
+        let path = String::from(dir.path().join(gen_name()).to_str().unwrap());
+        println!("Building temporary db: {}", path);
+
+        let pool = general::build_pool(&path).await.unwrap();
+        vector_state::init_table(&pool).await.unwrap();
+
+        (pool, dir)
+    }
+
+    #[tokio::test]
+    async fn test_db_init() {
+        init().await;
+    }
+
+    #[tokio::test]
+    async fn test_add() {
+        let (pool, _dir) = init().await;
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            vector_state::add(
+                &mut transaction,
+                &[row as u8; 1],
+                &format!("test_backup_network_{}", row),
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get() {
+        let (pool, _dir) = init().await;
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            vector_state::add(
+                &mut transaction,
+                &[row as u8; 1],
+                &format!("test_backup_network_{}", row),
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            assert_eq!(
+                vector_state::get(&mut transaction, &[row as u8; 1],)
+                    .await
+                    .unwrap(),
+                format!("test_backup_network_{}", row)
+            );
+        }
+        transaction.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_remove() {
+        let (pool, _dir) = init().await;
+        let num_rows = 10;
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            vector_state::add(
+                &mut transaction,
+                &[row as u8; 1],
+                &format!("test_backup_network_{}", row),
+            )
+            .await
+            .unwrap();
+        }
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            assert_eq!(
+                vector_state::get(&mut transaction, &[row as u8; 1],)
+                    .await
+                    .unwrap(),
+                format!("test_backup_network_{}", row)
+            );
+        }
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            vector_state::remove(&mut transaction, &[row as u8; 1])
+                .await
+                .unwrap();
+        }
+        transaction.commit().await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        for row in 0..num_rows {
+            assert!(vector_state::get(&mut transaction, &[row as u8; 1],)
+                .await
+                .is_err());
+        }
+        transaction.commit().await.unwrap();
+    }
+}

--- a/manager-rs/dauth-service/src/manager.rs
+++ b/manager-rs/dauth-service/src/manager.rs
@@ -18,24 +18,27 @@ use crate::rpc::clients;
 /// 3. Request a vector from all backup networks
 pub async fn find_vector(
     context: Arc<DauthContext>,
-    av_request: &AuthVectorReq,
+    user_id: &str,
+    network_id: &str,
 ) -> Result<AuthVectorRes, DauthError> {
-    tracing::info!("Attempting to find a vector: {:?}", av_request);
+    tracing::info!("Attempting to find a vector: {}-{}", user_id, network_id);
 
-    if let Ok(vector) = generate_auth_vector(context.clone(), av_request).await {
+    if let Ok(vector) = generate_auth_vector(
+        context.clone(),
+        user_id,
+        get_sqn_slice(context.clone(), user_id, network_id).await?,
+    )
+    .await
+    {
         Ok(vector)
     } else {
         let (home_network_id, backup_network_ids) =
-            clients::directory::lookup_user(context.clone(), &av_request.user_id).await?;
+            clients::directory::lookup_user(context.clone(), user_id).await?;
 
         let (home_address, _) =
             clients::directory::lookup_network(context.clone(), &home_network_id).await?;
-        if let Ok(vector) = clients::home_network::get_auth_vector(
-            context.clone(),
-            &av_request.user_id,
-            &home_address,
-        )
-        .await
+        if let Ok(vector) =
+            clients::home_network::get_auth_vector(context.clone(), user_id, &home_address).await
         {
             Ok(vector)
         } else {
@@ -44,7 +47,7 @@ pub async fn find_vector(
                     clients::directory::lookup_network(context.clone(), &backup_network_id).await?;
                 if let Ok(vector) = clients::backup_network::get_auth_vector(
                     context.clone(),
-                    &av_request.user_id,
+                    user_id,
                     &backup_address,
                 )
                 .await
@@ -61,18 +64,19 @@ pub async fn find_vector(
 }
 
 /// Generates and returns a new auth vector.
-/// Will fail if the requested id does not belong to this network/core.
 pub async fn generate_auth_vector(
     context: Arc<DauthContext>,
-    av_request: &AuthVectorReq,
+    user_id: &str,
+    sqn_slice: u32,
 ) -> Result<AuthVectorRes, DauthError> {
-    tracing::info!("Generating new vector: {:?}", av_request);
+    tracing::info!("Generating new vector: {}:{}", user_id, sqn_slice);
 
     let mut transaction = context.local_context.database_pool.begin().await?;
 
-    let mut user_info = database::user_infos::get(&mut transaction, &av_request.user_id)
-        .await?
-        .to_user_info()?;
+    let mut user_info =
+        database::user_infos::get(&mut transaction, &user_id.to_string(), sqn_slice)
+            .await?
+            .to_user_info()?;
 
     tracing::info!("User found: {:?}", user_info);
 
@@ -82,17 +86,18 @@ pub async fn generate_auth_vector(
     user_info.increment_sqn(32);
     database::user_infos::upsert(
         &mut transaction,
-        &av_request.user_id,
+        &user_id.to_string(),
         &user_info.k,
         &user_info.opc,
         &user_info.sqn_max,
+        sqn_slice,
     )
     .await?;
 
     let seqnum = utilities::convert_sqn_bytes_to_int(&user_info.sqn_max)?;
 
     let av_response = AuthVectorRes {
-        user_id: av_request.user_id.clone(),
+        user_id: user_id.to_string(),
         seqnum,
         rand: auth_vector_data.rand,
         autn: auth_vector_data.autn,
@@ -348,6 +353,22 @@ pub async fn remove_key_shares(
     }
     transaction.commit().await?;
     Ok(())
+}
+
+pub async fn get_sqn_slice(
+    context: Arc<DauthContext>,
+    user_id: &str,
+    network_id: &str,
+) -> Result<u32, DauthError> {
+    if network_id == context.local_context.id {
+        Ok(0)
+    } else {
+        let mut transaction = context.local_context.database_pool.begin().await?;
+        let slice =
+            database::backup_networks::get_slice(&mut transaction, user_id, network_id).await?;
+        transaction.commit().await?;
+        Ok(slice)
+    }
 }
 
 fn validate_xres_star_hash(

--- a/manager-rs/dauth-service/src/manager.rs
+++ b/manager-rs/dauth-service/src/manager.rs
@@ -83,7 +83,7 @@ pub async fn generate_auth_vector(
     // generate vector, then store new sqn max in the database
     let auth_vector_data =
         auth_vector::generate_vector(&user_info.k, &user_info.opc, &user_info.sqn_max);
-    user_info.increment_sqn(32);
+    user_info.increment_sqn(context.local_context.num_sqn_slices as u64);
     database::user_infos::upsert(
         &mut transaction,
         &user_id.to_string(),

--- a/manager-rs/dauth-service/src/manager.rs
+++ b/manager-rs/dauth-service/src/manager.rs
@@ -66,7 +66,7 @@ pub async fn find_vector(
 pub async fn generate_auth_vector(
     context: Arc<DauthContext>,
     user_id: &str,
-    sqn_slice: u32,
+    sqn_slice: i64,
 ) -> Result<AuthVectorRes, DauthError> {
     tracing::info!("Generating new vector: {}:{}", user_id, sqn_slice);
 
@@ -86,7 +86,7 @@ pub async fn generate_auth_vector(
         &user_info.sqn.to_be_bytes()[..SQN_LENGTH].try_into()?,
     );
 
-    user_info.sqn += context.local_context.num_sqn_slices as u64;
+    user_info.sqn += context.local_context.num_sqn_slices;
 
     database::user_infos::upsert(
         &mut transaction,
@@ -100,7 +100,7 @@ pub async fn generate_auth_vector(
 
     let av_response = AuthVectorRes {
         user_id: user_id.to_string(),
-        seqnum: user_info.sqn as i64,
+        seqnum: user_info.sqn,
         rand: auth_vector_data.rand,
         autn: auth_vector_data.autn,
         xres_star_hash: auth_vector_data.xres_star_hash,
@@ -361,7 +361,7 @@ pub async fn get_sqn_slice(
     context: Arc<DauthContext>,
     user_id: &str,
     network_id: &str,
-) -> Result<u32, DauthError> {
+) -> Result<i64, DauthError> {
     if network_id == context.local_context.id {
         Ok(0)
     } else {

--- a/manager-rs/dauth-service/src/rpc/clients/backup_network.rs
+++ b/manager-rs/dauth-service/src/rpc/clients/backup_network.rs
@@ -81,21 +81,21 @@ pub async fn enroll_backup_commit(
     context: Arc<DauthContext>,
     backup_network_id: &str,
     user_id: &str,
-    vectors: Vec<AuthVectorRes>,
-    key_shares: Vec<(HresStar, Kseaf)>,
+    vectors: &Vec<AuthVectorRes>,
+    key_shares: &Vec<(HresStar, Kseaf)>,
     address: &str,
 ) -> Result<(), DauthError> {
     let mut dvectors = Vec::new();
     let mut dshares = Vec::new();
 
-    for vector in &vectors {
+    for vector in vectors {
         dvectors.push(build_delegated_vector(
             context.clone(),
             vector,
             backup_network_id,
         ))
     }
-    for (xres_star_hash, confirmation_share) in &key_shares {
+    for (xres_star_hash, confirmation_share) in key_shares {
         dshares.push(build_delegated_share(
             context.clone(),
             xres_star_hash,

--- a/manager-rs/dauth-service/src/rpc/handlers/home_network.rs
+++ b/manager-rs/dauth-service/src/rpc/handlers/home_network.rs
@@ -5,7 +5,6 @@ use auth_vector::types::ResStar;
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;
 use crate::data::signing::{self, SignPayloadType};
-use crate::data::vector::AuthVectorReq;
 use crate::manager;
 use crate::rpc::dauth::common::AuthVector5G;
 use crate::rpc::dauth::remote::delegated_auth_vector5_g;
@@ -98,9 +97,9 @@ impl HomeNetworkHandler {
 
             let av_result = manager::generate_auth_vector(
                 context.clone(),
-                &AuthVectorReq {
-                    user_id: user_id.to_string(),
-                },
+                &user_id,
+                manager::get_sqn_slice(context.clone(), &user_id, &payload.serving_network_id)
+                    .await?,
             )
             .await?;
 

--- a/manager-rs/dauth-service/src/startup.rs
+++ b/manager-rs/dauth-service/src/startup.rs
@@ -56,12 +56,14 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
             &user_info.k,
             &user_info.opc,
             &user_info.sqn_max,
+            user_info.sqn_slice,
         )
         .await?;
 
         database::tasks::update_users::add(
             &mut transaction,
             &user_id,
+            user_info.sqn_slice,
             &user_info_config.backup_network_ids,
         )
         .await?;

--- a/manager-rs/dauth-service/src/startup.rs
+++ b/manager-rs/dauth-service/src/startup.rs
@@ -29,6 +29,7 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
             id: config.id,
             database_pool: pool,
             signing_keys: keys,
+            num_sqn_slices: config.num_sqn_slices,
             max_backup_vectors: config.max_backup_vectors,
         },
         rpc_context: RpcContext {
@@ -47,7 +48,9 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
     });
 
     for (user_id, user_info_config) in config.users {
-        let user_info = user_info_config.to_user_info()?;
+        let mut user_info = user_info_config.to_user_info()?;
+        user_info.sqn_slice %= context.local_context.num_sqn_slices;
+
         tracing::info!("inserting user info: {:?} - {:?}", user_id, user_info);
 
         let mut transaction = context.local_context.database_pool.begin().await?;

--- a/manager-rs/dauth-service/src/startup.rs
+++ b/manager-rs/dauth-service/src/startup.rs
@@ -68,7 +68,7 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
         )
         .await?;
 
-        if user_info_config.backup_network_ids.len() as u32 - 1
+        if user_info_config.backup_network_ids.len() as i64 - 1
             > context.local_context.num_sqn_slices
         {
             return Err(DauthError::ConfigError(format!(

--- a/manager-rs/dauth-service/src/startup.rs
+++ b/manager-rs/dauth-service/src/startup.rs
@@ -29,6 +29,7 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
             id: config.id,
             database_pool: pool,
             signing_keys: keys,
+            max_backup_vectors: config.max_backup_vectors,
         },
         rpc_context: RpcContext {
             host_addr: config.host_addr,

--- a/manager-rs/dauth-service/src/tasks/update_users.rs
+++ b/manager-rs/dauth-service/src/tasks/update_users.rs
@@ -58,7 +58,7 @@ async fn handle_user_update(context: Arc<DauthContext>, user_id: &str) -> Result
         let num_existing_vectors =
             database::vector_state::get_all_by_id(&mut transaction, user_id, backup_network_id)
                 .await?
-                .len() as u32;
+                .len() as i64;
         transaction.commit().await.unwrap();
 
         if num_existing_vectors > 0 {

--- a/manager-rs/dauth-service/src/tasks/update_users.rs
+++ b/manager-rs/dauth-service/src/tasks/update_users.rs
@@ -1,9 +1,14 @@
+use std::collections::HashMap;
 use std::sync::Arc;
+
+use auth_vector::constants::KSEAF_LENGTH;
+use auth_vector::types::{HresStar, Kseaf};
 
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;
-use crate::database;
+use crate::data::vector::AuthVectorRes;
 use crate::rpc::clients::{backup_network, directory};
+use crate::{database, manager};
 
 /// Runs the update user task.
 /// Iterates through user in the user update table.
@@ -37,13 +42,64 @@ async fn handle_user_update(context: Arc<DauthContext>, user_id: &str) -> Result
         database::tasks::update_users::get_user_data(&mut transaction, &user_id).await?;
 
     let mut backup_network_ids = Vec::new();
+    let mut vectors_map: HashMap<String, Vec<AuthVectorRes>> = HashMap::new();
+    let mut shares_map: HashMap<String, Vec<(HresStar, Kseaf)>> = HashMap::new();
 
-    for (backup_network_id, sqn_slice) in user_data {
+    // setup data structures
+    for (backup_network_id, _) in &user_data {
+        backup_network_ids.push(backup_network_id.clone());
+        vectors_map.insert(backup_network_id.clone(), Vec::new());
+        shares_map.insert(backup_network_id.clone(), Vec::new());
+    }
+
+    // TODO: add to config
+    let num_vectors = 10;
+    for _ in 0..num_vectors {
+        // build vectors and shares
+        for (backup_network_id, sqn_slice) in &user_data {
+            let vector =
+                manager::generate_auth_vector(context.clone(), user_id, *sqn_slice).await?;
+            let mut shares =
+                generate_key_shares(context.clone(), &vector, backup_network_ids.len() - 1).await?;
+
+            vectors_map
+                .get_mut(backup_network_id)
+                .ok_or_else(|| DauthError::DataError("Vectors map error".to_string()))?
+                .push(vector);
+
+            for other_id in &backup_network_ids {
+                if other_id != backup_network_id {
+                    shares_map
+                        .get_mut(other_id)
+                        .ok_or_else(|| DauthError::DataError("Shares map error".to_string()))?
+                        .push(shares.pop().ok_or_else(|| {
+                            DauthError::DataError("Shares list out of shares".to_string())
+                        })?);
+                }
+            }
+
+            if !shares.is_empty() {
+                tracing::warn!("Unused shares!")
+            }
+        }
+    }
+
+    for backup_network_id in &backup_network_ids {
         let (address, _) = directory::lookup_network(context.clone(), &backup_network_id).await?;
+
+        let vectors = vectors_map
+            .get(backup_network_id)
+            .ok_or_else(|| DauthError::DataError("Failed to get vectors".to_string()))?;
+        let shares = shares_map
+            .get(backup_network_id)
+            .ok_or_else(|| DauthError::DataError("Failed to get shares".to_string()))?;
+
+        // TODO: Add to network tables and vector state!
+
         backup_network::enroll_backup_prepare(
             context.clone(),
             user_id,
-            &backup_network_id,
+            backup_network_id,
             &address,
         )
         .await?;
@@ -51,15 +107,13 @@ async fn handle_user_update(context: Arc<DauthContext>, user_id: &str) -> Result
         // TODO: Add vector/key share generation
         backup_network::enroll_backup_commit(
             context.clone(),
-            &backup_network_id,
+            backup_network_id,
             user_id,
-            vec![],
-            vec![],
+            vectors,
+            shares,
             &address,
         )
         .await?;
-
-        backup_network_ids.push(backup_network_id);
     }
 
     directory::upsert_user(context.clone(), &user_id, backup_network_ids).await?;
@@ -68,4 +122,19 @@ async fn handle_user_update(context: Arc<DauthContext>, user_id: &str) -> Result
 
     transaction.commit().await.unwrap();
     Ok(())
+}
+
+/// Placeholder function for generating key shares
+async fn generate_key_shares(
+    _context: Arc<DauthContext>,
+    vector: &AuthVectorRes,
+    num_slices: usize,
+) -> Result<Vec<(HresStar, Kseaf)>, DauthError> {
+    let mut slices = Vec::new();
+
+    for _ in 0..num_slices {
+        slices.push((vector.xres_star_hash.clone(), [0u8; KSEAF_LENGTH]))
+    }
+
+    Ok(slices)
 }

--- a/manager-rs/dauth-service/src/tasks/update_users.rs
+++ b/manager-rs/dauth-service/src/tasks/update_users.rs
@@ -34,7 +34,7 @@ async fn handle_user_update(context: Arc<DauthContext>, user_id: &str) -> Result
     let mut transaction = context.local_context.database_pool.begin().await.unwrap();
 
     let user_data =
-        database::tasks::update_users::get_backup_network_ids(&mut transaction, &user_id).await?;
+        database::tasks::update_users::get_user_data(&mut transaction, &user_id).await?;
 
     let mut backup_network_ids = Vec::new();
 

--- a/manager-rs/dauth-service/src/tasks/update_users.rs
+++ b/manager-rs/dauth-service/src/tasks/update_users.rs
@@ -102,8 +102,13 @@ async fn handle_user_update(context: Arc<DauthContext>, user_id: &str) -> Result
         .await?;
 
         let mut transaction = context.local_context.database_pool.begin().await?;
-        database::backup_networks::add(&mut transaction, user_id, backup_network_id, *seqnum_slice)
-            .await?;
+        database::backup_networks::upsert(
+            &mut transaction,
+            user_id,
+            backup_network_id,
+            *seqnum_slice,
+        )
+        .await?;
         for vector in vectors {
             database::vector_state::add(
                 &mut transaction,


### PR DESCRIPTION
Added vector state (keeping track of vectors that are handed over to other networks) as well as adding sqn slices for each network. Vector generation is now possible for particular slices, and we can keep track of which network has which slice and the sqn max for each slice.

Vectors are generated during enrollment of backup networks, but replacements are not yet created since we need to add another RPC call for backup networks confirming auth from key shares.

Note: key shares are not properly generated yet.