### PR TITLE
Refactor directory service sqlite rows

### DIFF
--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -59,10 +59,7 @@ pub async fn lookup_user(
     let row = database::users::get(&mut transaction, user_id).await?;
     let home_network_id = row.try_get::<String, &str>("home_network_id")?;
 
-    let mut backup_network_ids = Vec::new();
-    for row in database::backups::get(&mut transaction, user_id).await? {
-        backup_network_ids.push(row.try_get::<String, &str>("backup_network_id")?)
-    }
+    let backup_network_ids = database::backups::get(&mut transaction, user_id).await?;
     transaction.commit().await?;
 
     Ok((home_network_id, backup_network_ids))

--- a/manager-rs/directory-service/src/manager.rs
+++ b/manager-rs/directory-service/src/manager.rs
@@ -39,12 +39,10 @@ pub async fn lookup_network(
     tracing::info!("Looup network called: {:?}", network_id);
 
     let mut transaction = context.database_pool.begin().await?;
-    let row = database::networks::get(&mut transaction, network_id).await?;
-    let address = row.try_get::<String, &str>("address")?;
-    let public_key = row.try_get::<Vec<u8>, &str>("public_key")?;
+    let res = database::networks::get(&mut transaction, network_id).await?;
     transaction.commit().await?;
 
-    Ok((address, public_key))
+    Ok(res)
 }
 
 /// Looks up a user by id.


### PR DESCRIPTION
Change all database query functions to return the expected data type rather than a sqlite row.

More info in #49.

I plan to do this for dauth-service as well, but this is a good sample of what I want to do.