### PR TITLE
Devel tokio metrics

### DIFF
--- a/services/Cargo.lock
+++ b/services/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
+ "tokio-metrics",
  "tonic",
  "tonic-build",
  "tracing",
@@ -506,6 +507,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -1686,6 +1699,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb585a0069b53171684e22d5255984ec30d1c7304fd0a4a9a603ffd8c765cdd"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/services/dauth-service/.cargo/config
+++ b/services/dauth-service/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+rustdocflags = ["--cfg", "tokio_unstable"]

--- a/services/dauth-service/Cargo.toml
+++ b/services/dauth-service/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 tonic = "^0.6.1"
 prost = "0.9"
 tokio = { version = "^1.13.0", features = ["macros", "rt-multi-thread"]}
+tokio-metrics = "0.1.0"
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 tracing-subscriber = {version = "0.3.11", features = ["fmt", "env-filter"]}

--- a/services/dauth-service/src/core/auth_vectors.rs
+++ b/services/dauth-service/src/core/auth_vectors.rs
@@ -215,7 +215,7 @@ pub async fn next_backup_auth_vector(
         vector = database::auth_vectors::get_first(&mut transaction, &av_request.user_id)
             .await?
             .to_auth_vector()?;
-        
+
         database::auth_vectors::remove(&mut transaction, &vector.user_id, vector.seqnum).await?;
 
         tracing::info!("Backup vector found: {:?}", vector);
@@ -272,13 +272,15 @@ pub async fn backup_auth_vector_used(
     )
     .await?;
 
-    let (_, backup_networks) =
-        clients::directory::lookup_user(context.clone(), &user_id).await?;
+    let (_, backup_networks) = clients::directory::lookup_user(context.clone(), &user_id).await?;
 
     let mut key_shares = keys::create_shares_from_kseaf(
         &auth_vector_data.kseaf,
         backup_networks.len() as u8,
-        std::cmp::min(keys::TEMPORARY_CONSTANT_THRESHOLD, backup_networks.len() as u8),
+        std::cmp::min(
+            keys::TEMPORARY_CONSTANT_THRESHOLD,
+            backup_networks.len() as u8,
+        ),
         &mut rand_0_8::thread_rng(),
     )?;
 
@@ -319,11 +321,8 @@ pub async fn build_auth_vector(
         .await?
         .to_user_info()?;
 
-    let auth_vector_data = auth_vector::generate_vector(
-        &user_info.k,
-        &user_info.opc,
-        &user_info.sqn.try_into()?,
-    );
+    let auth_vector_data =
+        auth_vector::generate_vector(&user_info.k, &user_info.opc, &user_info.sqn.try_into()?);
 
     user_info.sqn += context.local_context.num_sqn_slices;
 

--- a/services/dauth-service/src/core/confirm_keys.rs
+++ b/services/dauth-service/src/core/confirm_keys.rs
@@ -62,7 +62,10 @@ pub async fn confirm_authentication(
 
                 let mut key_shares = Vec::with_capacity(backup_network_ids.len());
                 let mut responses = Vec::with_capacity(backup_network_ids.len());
-                let share_threshold: u8 = std::cmp::min(keys::TEMPORARY_CONSTANT_THRESHOLD, backup_network_ids.len() as u8);
+                let share_threshold: u8 = std::cmp::min(
+                    keys::TEMPORARY_CONSTANT_THRESHOLD,
+                    backup_network_ids.len() as u8,
+                );
 
                 for backup_network_id in backup_network_ids {
                     let (backup_address, _) =
@@ -90,14 +93,15 @@ pub async fn confirm_authentication(
                 }
 
                 if key_shares.len() < share_threshold.into() {
-                    tracing::warn!("Insufficient valid responses {} of {} needed to compute the kseaf", key_shares.len(), share_threshold);
+                    tracing::warn!(
+                        "Insufficient valid responses {} of {} needed to compute the kseaf",
+                        key_shares.len(),
+                        share_threshold
+                    );
                     return Err(DauthError::ShamirShareError());
                 }
 
-                let kseaf = keys::recover_kseaf_from_shares(
-                    &key_shares,
-                    share_threshold,
-                )?;
+                let kseaf = keys::recover_kseaf_from_shares(&key_shares, share_threshold)?;
 
                 Ok(kseaf)
             }
@@ -135,7 +139,13 @@ pub async fn store_key_shares(
     let mut transaction = context.local_context.database_pool.begin().await?;
 
     for (xres_star_hash, key_share) in key_shares {
-        database::key_shares::add(&mut transaction, &xres_star_hash, user_id, key_share.as_slice()).await?;
+        database::key_shares::add(
+            &mut transaction,
+            &xres_star_hash,
+            user_id,
+            key_share.as_slice(),
+        )
+        .await?;
     }
     transaction.commit().await?;
     Ok(())

--- a/services/dauth-service/src/data/config.rs
+++ b/services/dauth-service/src/data/config.rs
@@ -23,6 +23,7 @@ pub struct DauthConfig {
     pub task_startup_delay: f64,
     pub task_interval: f64,
     pub local_auth_addr: Option<String>,
+    pub max_recorded_metrics: Option<i64>,
 }
 
 /// For ease of inputting content in the yaml file

--- a/services/dauth-service/src/data/context.rs
+++ b/services/dauth-service/src/data/context.rs
@@ -55,6 +55,8 @@ pub struct TasksContext {
     pub interval: Duration,
     pub is_registered: tokio::sync::Mutex<bool>,
     pub replace_key_share_delay: Duration,
+    pub metrics_report_interval: Duration,
+    pub metrics_last_report: tokio::sync::Mutex<Instant>,
 }
 
 /// Allow implementation of debug for TaskMonitor.

--- a/services/dauth-service/src/data/context.rs
+++ b/services/dauth-service/src/data/context.rs
@@ -2,6 +2,7 @@ use ed25519_dalek::{Keypair, PublicKey};
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
+
 use tonic::transport::Channel;
 
 use crate::data::state::AuthState;
@@ -18,6 +19,7 @@ pub struct DauthContext {
     pub backup_context: BackupContext,
     pub rpc_context: RpcContext,
     pub tasks_context: TasksContext,
+    pub metrics_context: MetricsContext,
 }
 
 #[derive(Debug)]
@@ -53,4 +55,48 @@ pub struct TasksContext {
     pub interval: Duration,
     pub is_registered: tokio::sync::Mutex<bool>,
     pub replace_key_share_delay: Duration,
+}
+
+/// Allow implementation of debug for TaskMonitor.
+struct TaskMonitorDebug(tokio_metrics::TaskMonitor);
+
+impl std::fmt::Debug for TaskMonitorDebug {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(fmt, "TaskMonitorDebug")
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MetricsContext {
+    monitors: tokio::sync::Mutex<HashMap<String, TaskMonitorDebug>>,
+}
+
+impl MetricsContext {
+    /// Returns the monitor for the provided monitor id.
+    /// Creates a new monitor if one does not exist.
+    async fn get_monitor(&self, monitor_id: &str) -> tokio_metrics::TaskMonitor {
+        let mut monitors = self.monitors.lock().await;
+
+        match monitors.get(monitor_id) {
+            Some(monitor) => monitor.0.clone(),
+            None => {
+                let monitor = tokio_metrics::TaskMonitor::new();
+                monitors.insert(monitor_id.to_string(), TaskMonitorDebug(monitor.clone()));
+                monitor
+            }
+        }
+    }
+
+    /// Returns a mapping of monitor ids to their current metrics.
+    /// Metrics are cumulative up to the point of calling this function.
+    async fn get_metrics(&self) -> HashMap<String, tokio_metrics::TaskMetrics> {
+        let monitors = self.monitors.lock().await;
+        let mut metrics = HashMap::with_capacity(monitors.len());
+
+        for (monitor_id, monitor) in monitors.iter() {
+            metrics.insert(monitor_id.clone(), monitor.0.cumulative());
+        }
+
+        metrics
+    }
 }

--- a/services/dauth-service/src/data/context.rs
+++ b/services/dauth-service/src/data/context.rs
@@ -74,7 +74,7 @@ pub struct MetricsContext {
 impl MetricsContext {
     /// Returns the monitor for the provided monitor id.
     /// Creates a new monitor if one does not exist.
-    async fn get_monitor(&self, monitor_id: &str) -> tokio_metrics::TaskMonitor {
+    pub async fn get_monitor(&self, monitor_id: &str) -> tokio_metrics::TaskMonitor {
         let mut monitors = self.monitors.lock().await;
 
         match monitors.get(monitor_id) {
@@ -89,7 +89,7 @@ impl MetricsContext {
 
     /// Returns a mapping of monitor ids to their current metrics.
     /// Metrics are cumulative up to the point of calling this function.
-    async fn get_metrics(&self) -> HashMap<String, tokio_metrics::TaskMetrics> {
+    pub async fn get_metrics(&self) -> HashMap<String, tokio_metrics::TaskMetrics> {
         let monitors = self.monitors.lock().await;
         let mut metrics = HashMap::with_capacity(monitors.len());
 

--- a/services/dauth-service/src/database/general.rs
+++ b/services/dauth-service/src/database/general.rs
@@ -1,5 +1,5 @@
-use sqlx::ConnectOptions;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+use sqlx::ConnectOptions;
 
 use crate::data::error::DauthError;
 use crate::database;

--- a/services/dauth-service/src/database/utilities.rs
+++ b/services/dauth-service/src/database/utilities.rs
@@ -3,9 +3,9 @@ use sqlx::sqlite::SqliteRow;
 use sqlx::Row;
 
 use crate::data::error::DauthError;
+use crate::data::keys;
 use crate::data::user_info::UserInfo;
 use crate::data::vector::AuthVectorRes;
-use crate::data::keys;
 
 pub trait DauthDataUtilities {
     fn to_auth_vector(&self) -> Result<AuthVectorRes, DauthError>;

--- a/services/dauth-service/src/rpc/clients/directory.rs
+++ b/services/dauth-service/src/rpc/clients/directory.rs
@@ -72,14 +72,14 @@ pub async fn lookup_user(
         Some(cached) => cached.clone(),
         None => {
             let mut client = get_client(context.clone()).await?;
-        
+
             let response = client
                 .lookup_user(LookupUserReq {
                     user_id: user_id.to_string(),
                 })
                 .await?
                 .into_inner();
-        
+
             let res = (response.home_network_id, response.backup_network_ids);
             cache.insert(user_id.to_string(), res.clone());
             res

--- a/services/dauth-service/src/rpc/handlers/backup_network.rs
+++ b/services/dauth-service/src/rpc/handlers/backup_network.rs
@@ -38,10 +38,9 @@ impl BackupNetwork for BackupNetworkHandler {
     ) -> Result<tonic::Response<EnrollBackupPrepareResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("backup_network::enroll_backup_prepare")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let message = request.into_inner().message.ok_or_else(|| {
                     tonic::Status::new(tonic::Code::NotFound, "No message received")
@@ -69,7 +68,13 @@ impl BackupNetwork for BackupNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("backup_network::enroll_backup_prepare", monitor)
+            .await;
+        res
     }
 
     /// Finishes the process of enrolling this network as a backup.
@@ -81,10 +86,9 @@ impl BackupNetwork for BackupNetworkHandler {
     ) -> Result<tonic::Response<EnrollBackupCommitResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("backup_network::enroll_backup_commit")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let content = request.into_inner();
                 match BackupNetworkHandler::enroll_backup_commit_hlp(self.context.clone(), content)
@@ -97,7 +101,13 @@ impl BackupNetwork for BackupNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("backup_network::enroll_backup_commit", monitor)
+            .await;
+        res
     }
 
     /// Retrieves an auth vector backup that has been stored by this network.
@@ -107,10 +117,9 @@ impl BackupNetwork for BackupNetworkHandler {
     ) -> Result<tonic::Response<GetBackupAuthVectorResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("backup_network::get_auth_vector")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let message = request.into_inner().message.ok_or_else(|| {
                     tonic::Status::new(tonic::Code::NotFound, "No message received")
@@ -147,7 +156,13 @@ impl BackupNetwork for BackupNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("backup_network::get_auth_vector", monitor)
+            .await;
+        res
     }
 
     /// Retrieves a key share that has been stored by this network.
@@ -157,10 +172,9 @@ impl BackupNetwork for BackupNetworkHandler {
     ) -> Result<tonic::Response<GetKeyShareResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("backup_network::get_key_share")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let message = request.into_inner().message.ok_or_else(|| {
                     tonic::Status::new(tonic::Code::NotFound, "No message received")
@@ -189,7 +203,13 @@ impl BackupNetwork for BackupNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("backup_network::get_key_share", monitor)
+            .await;
+        res
     }
 
     async fn replace_key_share(
@@ -198,10 +218,9 @@ impl BackupNetwork for BackupNetworkHandler {
     ) -> Result<tonic::Response<ReplaceShareResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("backup_network::replace_key_share")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 match BackupNetworkHandler::replace_key_share_hlp(
                     self.context.clone(),
@@ -216,7 +235,13 @@ impl BackupNetwork for BackupNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("backup_network::replace_key_share", monitor)
+            .await;
+        res
     }
 
     /// Removes the requested user id as a backup on this network.
@@ -227,10 +252,9 @@ impl BackupNetwork for BackupNetworkHandler {
     ) -> Result<tonic::Response<WithdrawBackupResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("backup_network::withdraw_backup")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let message = request.into_inner().message.ok_or_else(|| {
                     tonic::Status::new(tonic::Code::NotFound, "No message received")
@@ -255,7 +279,13 @@ impl BackupNetwork for BackupNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("backup_network::withdraw_backup", monitor)
+            .await;
+        res
     }
 
     async fn withdraw_shares(
@@ -264,10 +294,9 @@ impl BackupNetwork for BackupNetworkHandler {
     ) -> Result<tonic::Response<WithdrawSharesResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("backup_network::withdraw_shares")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let message = request.into_inner().message.ok_or_else(|| {
                     tonic::Status::new(tonic::Code::NotFound, "No message received")
@@ -292,7 +321,13 @@ impl BackupNetwork for BackupNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("backup_network::withdraw_shares", monitor)
+            .await;
+        res
     }
 
     async fn flood_vector(
@@ -301,10 +336,9 @@ impl BackupNetwork for BackupNetworkHandler {
     ) -> Result<tonic::Response<FloodVectorResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("backup_network::flood_vector")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let message = request.into_inner().message.ok_or_else(|| {
                     tonic::Status::new(tonic::Code::NotFound, "No message received")
@@ -329,7 +363,13 @@ impl BackupNetwork for BackupNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("backup_network::flood_vector", monitor)
+            .await;
+        res
     }
 }
 

--- a/services/dauth-service/src/rpc/handlers/home_network.rs
+++ b/services/dauth-service/src/rpc/handlers/home_network.rs
@@ -30,29 +30,38 @@ impl HomeNetwork for HomeNetworkHandler {
     ) -> Result<tonic::Response<GetHomeAuthVectorResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        let message = request
-            .into_inner()
-            .message
-            .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "No message received"))?;
-
-        let verify_result = signing::verify_message(self.context.clone(), &message)
+        self.context
+            .metrics_context
+            .get_monitor("home_network::get_auth_vector")
             .await
-            .or_else(|e| {
-                Err(tonic::Status::new(
-                    tonic::Code::Unauthenticated,
-                    format!("Failed to verify message: {}", e),
-                ))
-            })?;
+            .instrument(async move {
+                let message = request.into_inner().message.ok_or_else(|| {
+                    tonic::Status::new(tonic::Code::NotFound, "No message received")
+                })?;
 
-        match HomeNetworkHandler::get_home_auth_vector_hlp(self.context.clone(), verify_result)
+                let verify_result = signing::verify_message(self.context.clone(), &message)
+                    .await
+                    .or_else(|e| {
+                        Err(tonic::Status::new(
+                            tonic::Code::Unauthenticated,
+                            format!("Failed to verify message: {}", e),
+                        ))
+                    })?;
+
+                match HomeNetworkHandler::get_home_auth_vector_hlp(
+                    self.context.clone(),
+                    verify_result,
+                )
+                .await
+                {
+                    Ok(result) => Ok(result),
+                    Err(e) => Err(tonic::Status::new(
+                        tonic::Code::Aborted,
+                        format!("Error while handling request: {}", e),
+                    )),
+                }
+            })
             .await
-        {
-            Ok(result) => Ok(result),
-            Err(e) => Err(tonic::Status::new(
-                tonic::Code::Aborted,
-                format!("Error while handling request: {}", e),
-            )),
-        }
     }
 
     /// Remote request for to complete auth process for a vector.
@@ -63,27 +72,35 @@ impl HomeNetwork for HomeNetworkHandler {
     ) -> Result<tonic::Response<GetHomeConfirmKeyResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        let message = request
-            .into_inner()
-            .message
-            .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "No message received"))?;
-
-        let verify_result = signing::verify_message(self.context.clone(), &message)
+        self.context
+            .metrics_context
+            .get_monitor("home_network::get_confirm_key")
             .await
-            .or_else(|e| {
-                Err(tonic::Status::new(
-                    tonic::Code::Unauthenticated,
-                    format!("Failed to verify message: {}", e),
-                ))
-            })?;
+            .instrument(async move {
+                let message = request.into_inner().message.ok_or_else(|| {
+                    tonic::Status::new(tonic::Code::NotFound, "No message received")
+                })?;
 
-        match HomeNetworkHandler::get_confirm_key_hlp(self.context.clone(), verify_result).await {
-            Ok(result) => Ok(result),
-            Err(e) => Err(tonic::Status::new(
-                tonic::Code::Aborted,
-                format!("Error while handling request: {}", e),
-            )),
-        }
+                let verify_result = signing::verify_message(self.context.clone(), &message)
+                    .await
+                    .or_else(|e| {
+                        Err(tonic::Status::new(
+                            tonic::Code::Unauthenticated,
+                            format!("Failed to verify message: {}", e),
+                        ))
+                    })?;
+
+                match HomeNetworkHandler::get_confirm_key_hlp(self.context.clone(), verify_result)
+                    .await
+                {
+                    Ok(result) => Ok(result),
+                    Err(e) => Err(tonic::Status::new(
+                        tonic::Code::Aborted,
+                        format!("Error while handling request: {}", e),
+                    )),
+                }
+            })
+            .await
     }
 
     /// Remote request to report an auth vector as used.
@@ -94,35 +111,41 @@ impl HomeNetwork for HomeNetworkHandler {
     ) -> Result<tonic::Response<ReportHomeAuthConsumedResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        let content = request.into_inner();
-
-        let message = content
-            .backup_auth_vector_req
-            .clone()
-            .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "No message received"))?;
-
-        let verify_result = signing::verify_message(self.context.clone(), &message)
+        self.context
+            .metrics_context
+            .get_monitor("home_network::report_auth_consumed")
             .await
-            .or_else(|e| {
-                Err(tonic::Status::new(
-                    tonic::Code::Unauthenticated,
-                    format!("Failed to verify message: {}", e),
-                ))
-            })?;
+            .instrument(async move {
+                let content = request.into_inner();
 
-        match HomeNetworkHandler::report_auth_consumed_hlp(
-            self.context.clone(),
-            content,
-            verify_result,
-        )
-        .await
-        {
-            Ok(result) => Ok(result),
-            Err(e) => Err(tonic::Status::new(
-                tonic::Code::Aborted,
-                format!("Error while handling request: {}", e),
-            )),
-        }
+                let message = content.backup_auth_vector_req.clone().ok_or_else(|| {
+                    tonic::Status::new(tonic::Code::NotFound, "No message received")
+                })?;
+
+                let verify_result = signing::verify_message(self.context.clone(), &message)
+                    .await
+                    .or_else(|e| {
+                        Err(tonic::Status::new(
+                            tonic::Code::Unauthenticated,
+                            format!("Failed to verify message: {}", e),
+                        ))
+                    })?;
+
+                match HomeNetworkHandler::report_auth_consumed_hlp(
+                    self.context.clone(),
+                    content,
+                    verify_result,
+                )
+                .await
+                {
+                    Ok(result) => Ok(result),
+                    Err(e) => Err(tonic::Status::new(
+                        tonic::Code::Aborted,
+                        format!("Error while handling request: {}", e),
+                    )),
+                }
+            })
+            .await
     }
 
     /// Remote request to report a key share as used.
@@ -133,34 +156,41 @@ impl HomeNetwork for HomeNetworkHandler {
     ) -> Result<tonic::Response<ReportHomeKeyShareConsumedResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        let content = request.into_inner();
-
-        let message = content
-            .get_key_share_req
-            .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "No message received"))?;
-
-        let verify_result = signing::verify_message(self.context.clone(), &message)
+        self.context
+            .metrics_context
+            .get_monitor("home_network::report_key_share_consumed")
             .await
-            .or_else(|e| {
-                Err(tonic::Status::new(
-                    tonic::Code::Unauthenticated,
-                    format!("Failed to verify message: {}", e),
-                ))
-            })?;
+            .instrument(async move {
+                let content = request.into_inner();
 
-        match HomeNetworkHandler::report_key_share_consumed_hlp(
-            self.context.clone(),
-            &content.backup_network_id,
-            verify_result,
-        )
-        .await
-        {
-            Ok(result) => Ok(result),
-            Err(e) => Err(tonic::Status::new(
-                tonic::Code::Aborted,
-                format!("Error while handling request: {}", e),
-            )),
-        }
+                let message = content.get_key_share_req.ok_or_else(|| {
+                    tonic::Status::new(tonic::Code::NotFound, "No message received")
+                })?;
+
+                let verify_result = signing::verify_message(self.context.clone(), &message)
+                    .await
+                    .or_else(|e| {
+                        Err(tonic::Status::new(
+                            tonic::Code::Unauthenticated,
+                            format!("Failed to verify message: {}", e),
+                        ))
+                    })?;
+
+                match HomeNetworkHandler::report_key_share_consumed_hlp(
+                    self.context.clone(),
+                    &content.backup_network_id,
+                    verify_result,
+                )
+                .await
+                {
+                    Ok(result) => Ok(result),
+                    Err(e) => Err(tonic::Status::new(
+                        tonic::Code::Aborted,
+                        format!("Error while handling request: {}", e),
+                    )),
+                }
+            })
+            .await
     }
 }
 

--- a/services/dauth-service/src/rpc/handlers/home_network.rs
+++ b/services/dauth-service/src/rpc/handlers/home_network.rs
@@ -30,10 +30,9 @@ impl HomeNetwork for HomeNetworkHandler {
     ) -> Result<tonic::Response<GetHomeAuthVectorResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("home_network::get_auth_vector")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let message = request.into_inner().message.ok_or_else(|| {
                     tonic::Status::new(tonic::Code::NotFound, "No message received")
@@ -61,7 +60,13 @@ impl HomeNetwork for HomeNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("home_network::get_auth_vector", monitor)
+            .await;
+        res
     }
 
     /// Remote request for to complete auth process for a vector.
@@ -72,10 +77,9 @@ impl HomeNetwork for HomeNetworkHandler {
     ) -> Result<tonic::Response<GetHomeConfirmKeyResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("home_network::get_confirm_key")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let message = request.into_inner().message.ok_or_else(|| {
                     tonic::Status::new(tonic::Code::NotFound, "No message received")
@@ -100,7 +104,13 @@ impl HomeNetwork for HomeNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("home_network::get_confirm_key", monitor)
+            .await;
+        res
     }
 
     /// Remote request to report an auth vector as used.
@@ -111,10 +121,9 @@ impl HomeNetwork for HomeNetworkHandler {
     ) -> Result<tonic::Response<ReportHomeAuthConsumedResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("home_network::report_auth_consumed")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let content = request.into_inner();
 
@@ -145,7 +154,13 @@ impl HomeNetwork for HomeNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("home_network::report_auth_consumed", monitor)
+            .await;
+        res
     }
 
     /// Remote request to report a key share as used.
@@ -156,10 +171,9 @@ impl HomeNetwork for HomeNetworkHandler {
     ) -> Result<tonic::Response<ReportHomeKeyShareConsumedResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        self.context
-            .metrics_context
-            .get_monitor("home_network::report_key_share_consumed")
-            .await
+        let monitor = tokio_metrics::TaskMonitor::new();
+
+        let res = monitor
             .instrument(async move {
                 let content = request.into_inner();
 
@@ -190,7 +204,13 @@ impl HomeNetwork for HomeNetworkHandler {
                     )),
                 }
             })
-            .await
+            .await;
+
+        self.context
+            .metrics_context
+            .record_metrics("home_network::report_key_share_consumed", monitor)
+            .await;
+        res
     }
 }
 

--- a/services/dauth-service/src/rpc/handlers/local_authentication.rs
+++ b/services/dauth-service/src/rpc/handlers/local_authentication.rs
@@ -23,29 +23,36 @@ impl LocalAuthentication for LocalAuthenticationHandler {
     ) -> Result<tonic::Response<AkaVectorResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        let content = request.into_inner();
-        let user_id: String;
-        match std::str::from_utf8(content.user_id.as_slice()) {
-            Ok(res) => user_id = res.to_string(),
-            Err(e) => return Err(tonic::Status::new(tonic::Code::Aborted, e.to_string())),
-        }
+        self.context
+            .metrics_context
+            .get_monitor("local_authentication::get_auth_vector")
+            .await
+            .instrument(async move {
+                let content = request.into_inner();
+                let user_id: String;
+                match std::str::from_utf8(content.user_id.as_slice()) {
+                    Ok(res) => user_id = res.to_string(),
+                    Err(e) => return Err(tonic::Status::new(tonic::Code::Aborted, e.to_string())),
+                }
 
-        match core::auth_vectors::find_vector(
-            self.context.clone(),
-            &user_id,
-            &self.context.local_context.id,
-        )
-        .await
-        {
-            Ok(av_result) => {
-                tracing::info!("Returning result: {:?}", av_result);
-                Ok(tonic::Response::new(av_result.to_resp()))
-            }
-            Err(e) => {
-                tracing::error!("Error while handling request: {}", e);
-                Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
-            }
-        }
+                match core::auth_vectors::find_vector(
+                    self.context.clone(),
+                    &user_id,
+                    &self.context.local_context.id,
+                )
+                .await
+                {
+                    Ok(av_result) => {
+                        tracing::info!("Returning result: {:?}", av_result);
+                        Ok(tonic::Response::new(av_result.to_resp()))
+                    }
+                    Err(e) => {
+                        tracing::error!("Error while handling request: {}", e);
+                        Err(tonic::Status::new(tonic::Code::Aborted, e.to_string()))
+                    }
+                }
+            })
+            .await
     }
 
     /// Local request for to complete auth process for a vector.
@@ -56,17 +63,24 @@ impl LocalAuthentication for LocalAuthenticationHandler {
     ) -> Result<tonic::Response<AkaConfirmResp>, tonic::Status> {
         tracing::info!("Request: {:?}", request);
 
-        match self.confirm_auth_hlp(request.into_inner()).await {
-            Ok(kseaf) => {
-                let response_payload = AkaConfirmResp {
-                    error: aka_confirm_resp::ErrorKind::NoError as i32,
-                    kseaf: kseaf.to_vec(),
-                };
+        self.context
+            .metrics_context
+            .get_monitor("local_authentication::confirm_auth")
+            .await
+            .instrument(async move {
+                match self.confirm_auth_hlp(request.into_inner()).await {
+                    Ok(kseaf) => {
+                        let response_payload = AkaConfirmResp {
+                            error: aka_confirm_resp::ErrorKind::NoError as i32,
+                            kseaf: kseaf.to_vec(),
+                        };
 
-                Ok(tonic::Response::new(response_payload))
-            }
-            Err(e) => Err(tonic::Status::new(tonic::Code::NotFound, e.to_string())),
-        }
+                        Ok(tonic::Response::new(response_payload))
+                    }
+                    Err(e) => Err(tonic::Status::new(tonic::Code::NotFound, e.to_string())),
+                }
+            })
+            .await
     }
 }
 

--- a/services/dauth-service/src/rpc/server.rs
+++ b/services/dauth-service/src/rpc/server.rs
@@ -14,33 +14,39 @@ use crate::rpc::dauth::remote::home_network_server::HomeNetworkServer;
 // TODO(matt9j) Probably should return a result in case server start fails
 #[tracing::instrument]
 pub async fn start_servers(context: Arc<DauthContext>) {
-    tracing::info!("Hosting remote-facing RPC server on {}", context.rpc_context.host_addr);
+    tracing::info!(
+        "Hosting remote-facing RPC server on {}",
+        context.rpc_context.host_addr
+    );
     let host_ip: std::net::SocketAddr = context.rpc_context.host_addr.parse().unwrap();
     let external_server_join_handle = tokio::spawn(
         Server::builder()
-        .add_service(HomeNetworkServer::new(HomeNetworkHandler {
-            context: context.clone(),
-        }))
-        .add_service(BackupNetworkServer::new(BackupNetworkHandler {
-            context: context.clone(),
-        }))
-        .serve(host_ip)
+            .add_service(HomeNetworkServer::new(HomeNetworkHandler {
+                context: context.clone(),
+            }))
+            .add_service(BackupNetworkServer::new(BackupNetworkHandler {
+                context: context.clone(),
+            }))
+            .serve(host_ip),
     );
 
-    tracing::info!("Hosting local-auth RPC server on {}", context.rpc_context.local_auth_addr);
+    tracing::info!(
+        "Hosting local-auth RPC server on {}",
+        context.rpc_context.local_auth_addr
+    );
     let local_ip: std::net::SocketAddr = context.rpc_context.local_auth_addr.parse().unwrap();
     let local_server_join_handle = tokio::spawn(
         Server::builder()
-        .add_service(LocalAuthenticationServer::new(LocalAuthenticationHandler {
-            context: context.clone(),
-        }))
-        .serve(local_ip)
+            .add_service(LocalAuthenticationServer::new(LocalAuthenticationHandler {
+                context: context.clone(),
+            }))
+            .serve(local_ip),
     );
 
     // Select will await on each arm, and then return when the first task is
     // complete. Select! cancells the other future, but this is okay since we
     // want to shutdown all endpoints if one of the endpoints fails.
-    tokio::select!{
+    tokio::select! {
         _ = external_server_join_handle => {
             tracing::error!("Remote facing RPC server exited!")
         }

--- a/services/dauth-service/src/startup.rs
+++ b/services/dauth-service/src/startup.rs
@@ -55,6 +55,8 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
             interval: Duration::from_secs_f64(config.task_interval),
             is_registered: tokio::sync::Mutex::new(false),
             replace_key_share_delay: Duration::from_secs_f64(10.0),
+            metrics_report_interval: Duration::from_secs_f64(10.0),
+            metrics_last_report: tokio::sync::Mutex::new(Instant::now()),
         },
         metrics_context: MetricsContext::default(),
     });

--- a/services/dauth-service/src/startup.rs
+++ b/services/dauth-service/src/startup.rs
@@ -12,7 +12,9 @@ use serde_yaml;
 
 use crate::data::{
     config::DauthConfig,
-    context::{BackupContext, DauthContext, LocalContext, RpcContext, TasksContext},
+    context::{
+        BackupContext, DauthContext, LocalContext, MetricsContext, RpcContext, TasksContext,
+    },
     error::DauthError,
     opt::DauthOpt,
 };
@@ -40,7 +42,9 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
         rpc_context: RpcContext {
             host_addr: config.host_addr,
             directory_addr: config.directory_addr,
-            local_auth_addr: config.local_auth_addr.unwrap_or("127.0.0.1:50051".to_owned()),
+            local_auth_addr: config
+                .local_auth_addr
+                .unwrap_or("127.0.0.1:50051".to_owned()),
             backup_clients: tokio::sync::Mutex::new(HashMap::new()),
             home_clients: tokio::sync::Mutex::new(HashMap::new()),
             directory_client: tokio::sync::Mutex::new(None),
@@ -52,6 +56,7 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
             is_registered: tokio::sync::Mutex::new(false),
             replace_key_share_delay: Duration::from_secs_f64(10.0),
         },
+        metrics_context: MetricsContext::default(),
     });
 
     for (user_id, user_info_config) in config.users {

--- a/services/dauth-service/src/startup.rs
+++ b/services/dauth-service/src/startup.rs
@@ -58,7 +58,10 @@ pub async fn build_context(dauth_opt: DauthOpt) -> Result<Arc<DauthContext>, Dau
             metrics_report_interval: Duration::from_secs_f64(10.0),
             metrics_last_report: tokio::sync::Mutex::new(Instant::now()),
         },
-        metrics_context: MetricsContext::default(),
+        metrics_context: MetricsContext {
+            max_recorded_metrics: config.max_recorded_metrics.unwrap_or(100) as usize,
+            metrics_map: tokio::sync::Mutex::new(HashMap::new()),
+        },
     });
 
     for (user_id, user_info_config) in config.users {

--- a/services/dauth-service/src/tasks/metrics.rs
+++ b/services/dauth-service/src/tasks/metrics.rs
@@ -1,0 +1,13 @@
+use std::sync::Arc;
+
+use crate::data::context::DauthContext;
+use crate::data::error::DauthError;
+
+/// Runs the metrics task.
+pub async fn run_task(context: Arc<DauthContext>) -> Result<(), DauthError> {
+    let metrics = context.metrics_context.get_metrics().await;
+
+    tracing::info!("{:?}", metrics);
+
+    Ok(())
+}

--- a/services/dauth-service/src/tasks/metrics.rs
+++ b/services/dauth-service/src/tasks/metrics.rs
@@ -1,13 +1,18 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;
 
 /// Runs the metrics task.
 pub async fn run_task(context: Arc<DauthContext>) -> Result<(), DauthError> {
+    let mut last_report = context.tasks_context.metrics_last_report.lock().await;
     let metrics = context.metrics_context.get_metrics().await;
 
-    tracing::info!("{:?}", metrics);
+    if last_report.elapsed() > context.tasks_context.metrics_report_interval {
+        tracing::info!("{:?}", metrics);
+        *last_report = Instant::now();
+    }
 
     Ok(())
 }

--- a/services/dauth-service/src/tasks/metrics.rs
+++ b/services/dauth-service/src/tasks/metrics.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::data::context::DauthContext;
 use crate::data::error::DauthError;
@@ -7,10 +8,43 @@ use crate::data::error::DauthError;
 /// Runs the metrics task.
 pub async fn run_task(context: Arc<DauthContext>) -> Result<(), DauthError> {
     let mut last_report = context.tasks_context.metrics_last_report.lock().await;
-    let metrics = context.metrics_context.get_metrics().await;
 
-    if last_report.elapsed() > context.tasks_context.metrics_report_interval {
-        tracing::info!("{:?}", metrics);
+    if last_report.elapsed() > context.tasks_context.metrics_report_interval
+        && context.metrics_context.max_recorded_metrics > 0
+    {
+        let all_metrics = context.metrics_context.get_metrics().await;
+
+        for (metric_id, metrics) in all_metrics {
+            let mut metric_results =
+                HashMap::with_capacity(context.metrics_context.max_recorded_metrics);
+            let mut idle_times = Vec::with_capacity(context.metrics_context.max_recorded_metrics);
+            let mut polling_times =
+                Vec::with_capacity(context.metrics_context.max_recorded_metrics);
+
+            for metric in metrics {
+                idle_times.push(metric.total_idle_duration);
+                polling_times.push(metric.total_poll_duration);
+            }
+
+            metric_results.insert("idle times", format!("{:?}", idle_times));
+            metric_results.insert("polling times", format!("{:?}", polling_times));
+
+            let (idle_len, polling_len) = (idle_times.len() as u32, polling_times.len() as u32);
+            metric_results.insert(
+                "idle average",
+                format!("{:?}", idle_times.into_iter().sum::<Duration>() / idle_len),
+            );
+            metric_results.insert(
+                "polling average",
+                format!(
+                    "{:?}",
+                    polling_times.into_iter().sum::<Duration>() / polling_len
+                ),
+            );
+
+            tracing::info!("Metrics for {}: {:?}", metric_id, metric_results);
+        }
+
         *last_report = Instant::now();
     }
 

--- a/services/dauth-service/src/tasks/mod.rs
+++ b/services/dauth-service/src/tasks/mod.rs
@@ -1,3 +1,4 @@
+mod metrics;
 mod register;
 mod replace_key_shares;
 mod report_auth_vectors;

--- a/services/dauth-service/src/tasks/task_manager.rs
+++ b/services/dauth-service/src/tasks/task_manager.rs
@@ -45,6 +45,7 @@ async fn run(context: Arc<DauthContext>) -> Result<(), DauthError> {
             tasks.push(tokio::spawn(tasks::report_key_shares::run_task(
                 context.clone(),
             )));
+            tasks.push(tokio::spawn(tasks::metrics::run_task(context.clone())));
 
             for task in tasks {
                 match task.await {

--- a/services/dauth-service/src/tasks/update_users.rs
+++ b/services/dauth-service/src/tasks/update_users.rs
@@ -103,7 +103,10 @@ async fn handle_user_update(context: Arc<DauthContext>, user_id: String) -> Resu
                 keys::create_shares_from_kseaf(
                     &vector.kseaf,
                     backup_network_ids.len() as u8,
-                    std::cmp::min(keys::TEMPORARY_CONSTANT_THRESHOLD, backup_network_ids.len() as u8),
+                    std::cmp::min(
+                        keys::TEMPORARY_CONSTANT_THRESHOLD,
+                        backup_network_ids.len() as u8,
+                    ),
                     &mut rng,
                 )?
                 .into_iter()


### PR DESCRIPTION
Added simple metrics to each of the handlers on the dauth service. It should provide various tokio metrics, but most importantly the time spend polling (basically executing) and the time spent idle. A task will periodically log the current metrics. Metrics are reset on service restart.